### PR TITLE
fix(ci): force --to-latest traffic shift after deploy-dev

### DIFF
--- a/.github/workflows/preprocess-deploy.yml
+++ b/.github/workflows/preprocess-deploy.yml
@@ -333,7 +333,7 @@ jobs:
           echo "Previous dev revision: $PREV"
           echo "prev_revision=$PREV" >> $GITHUB_OUTPUT
 
-      - name: Deploy to dev Cloud Run (immediate traffic)
+      - name: Deploy to dev Cloud Run
         uses: google-github-actions/deploy-cloudrun@v2
         with:
           service: neonbinder-preprocess
@@ -341,6 +341,20 @@ jobs:
           image: gcr.io/neonbinder-dev/neonbinder-preprocess:${{ github.sha }}
           project_id: neonbinder-dev
           env_vars: ENVIRONMENT=dev
+
+      # deploy-cloudrun@v2 only auto-routes traffic to the new revision when
+      # the service's traffic config is already at `latest_revision = true`.
+      # Our service history (bootstrap cloudrun/hello revision + intermittent
+      # PR-preview tags) flips traffic into explicit-revision mode, so the
+      # implicit latest-revision routing never fires. Force the shift
+      # explicitly so dev always serves main's HEAD after a merge.
+      - name: Shift dev traffic to latest revision
+        run: |
+          set -euo pipefail
+          gcloud run services update-traffic neonbinder-preprocess \
+            --region=us-central1 \
+            --project=neonbinder-dev \
+            --to-latest
 
   dev-smoke:
     needs: deploy-dev


### PR DESCRIPTION
## Summary

First push-to-main run after merging PR #1 failed at `dev-smoke`: the new revision was created but traffic stayed on the `gcr.io/cloudrun/hello` bootstrap revision.

## Root cause

`deploy-cloudrun@v2` only auto-routes traffic to the new revision when the service's traffic config is already at `latest_revision = true`. Our service started in explicit-revision mode (terraform pinned it to `gcr.io/cloudrun/hello`, and preview deploys added `pr-<N>` tags), so the implicit latest-revision routing never fired.

## Fix

Add an explicit `gcloud run services update-traffic --to-latest` step after `deploy-cloudrun` in `deploy-dev`. Idempotent and deterministic — same effect in both the first-deploy and steady-state cases.

`deploy-prod` is intentionally unchanged — it uses blue/green (no-traffic + sha tag) and `prod-promote` does an explicit `--to-revisions=<new>=100` after smoke passes.

## Verified manually

Ran `gcloud run services update-traffic neonbinder-preprocess --to-latest` against the stuck dev service — traffic shifted to `00006-zng` (our real image), `/health` immediately returned `200 {"status":"ok"}`.

## Test plan

- [ ] This PR's `preview-smoke` passes (preview URL uses a tag, so traffic is explicit by design there — already works).
- [ ] Merge fires the full pipeline; `deploy-dev` + the new `Shift dev traffic to latest revision` step routes traffic to the new revision.
- [ ] `dev-smoke` passes this time.
- [ ] `deploy-prod` + `prod-smoke` + `prod-promote` complete, prod Cloud Run stops serving `cloudrun/hello`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)