### PR TITLE
feat(slice-2a): crop cascade — precropped → pil_trim → passthrough

### DIFF
--- a/app/cropper.py
+++ b/app/cropper.py
@@ -1,6 +1,0 @@
-"""SAM-based crop fallback.
-
-Slice 2 target (after slice 1 ships orient + classify). Will port
-card_cropper_sam.py from script-frontend with HTTP handling replacing the
-persistent-worker stdin loop. Placeholder until then.
-"""

--- a/app/cropper/__init__.py
+++ b/app/cropper/__init__.py
@@ -1,0 +1,103 @@
+"""Crop cascade orchestration.
+
+Mirrors the cropAttempts waterfall from the script-frontend's imageProcessor.js
+but restricted to strategies that run server-side (macOS Swift croppers stay
+client-side).
+
+The cascade runs each strategy in order; the first one whose output passes
+`validator.is_plausible_crop` wins. Strategies that raise, return None, or
+produce a crop that fails validation are skipped silently and the next
+strategy runs.
+
+Each strategy is a pure function `(image_bytes) -> bytes | None`. The
+cascade itself returns a `CropResult` with the winning source label plus
+the resulting bytes.
+
+Source labels (order of preference):
+    precropped : client supplied a valid crop candidate
+    pil_trim   : PIL blur + threshold + trim + expand (sharp.trim port)
+    sam        : [slice 2b] SAM semantic segmentation
+    haiku_bbox : [slice 2c] Anthropic Haiku bbox
+    passthrough: last resort, input returned unchanged
+
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from app.cropper import pil_trim
+from app.cropper.validator import is_plausible_crop
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class CropResult:
+    """Outcome of the cascade.
+
+    image_bytes: final cropped image (may equal the input if source == "passthrough").
+    source:      label of the winning strategy.
+    returned_bytes_differ: True when image_bytes != the caller's original upload,
+                           i.e. the response should include cropped_image_b64.
+                           False when source == "precropped" (client already has
+                           these exact bytes on disk).
+    """
+
+    image_bytes: bytes
+    source: str
+    returned_bytes_differ: bool
+
+
+def crop(
+    *,
+    image_bytes: bytes,
+    precropped_bytes: bytes | None,
+) -> CropResult:
+    """Run the crop cascade and return the first successful result.
+
+    When `precropped_bytes` is provided, that's tried first. When it's absent,
+    the `image` upload is treated as the precropped candidate — preserves
+    backward compat with slice-1 callers who already do their own cropping
+    and send only `image`.
+    """
+    # Stage 1 — validate the precropped candidate (or image as fallback).
+    candidate = precropped_bytes if precropped_bytes is not None else image_bytes
+    source_label = "precropped"
+    check = is_plausible_crop(candidate)
+    if check.ok:
+        return CropResult(
+            image_bytes=candidate,
+            source=source_label,
+            returned_bytes_differ=False,
+        )
+    logger.info("cascade: precropped candidate rejected (%s)", check.reason)
+
+    # Stage 2 — PIL trim on the original image.
+    try:
+        trimmed = pil_trim.trim(image_bytes)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("cascade: pil_trim raised %s", exc)
+        trimmed = None
+    if trimmed is not None:
+        check = is_plausible_crop(trimmed, source_area_bytes=image_bytes)
+        if check.ok:
+            return CropResult(
+                image_bytes=trimmed,
+                source="pil_trim",
+                returned_bytes_differ=True,
+            )
+        logger.info("cascade: pil_trim rejected (%s)", check.reason)
+
+    # TODO(slice-2b): insert `sam` strategy here.
+    # TODO(slice-2c): insert `haiku_bbox` strategy here.
+
+    # Stage N — passthrough. Return original unchanged so orient+classify have
+    # something to work with even when every cropper failed.
+    logger.info("cascade: falling through to passthrough")
+    return CropResult(
+        image_bytes=image_bytes,
+        source="passthrough",
+        returned_bytes_differ=False,
+    )

--- a/app/cropper/pil_trim.py
+++ b/app/cropper/pil_trim.py
@@ -1,0 +1,91 @@
+"""PIL-based trim — port of script-frontend's sharp.trim strategy.
+
+Works well on photos of cards on a near-solid (usually black or dark)
+background: blur to smooth noise, threshold out dark pixels, take the
+bounding box of the remaining content, then add a small border back so the
+next stages (orient, classify) don't clip the card edge.
+
+This replaces both `sharp.trim` and `magick.fuzz.trim` from the original
+cascade — they solve the same problem (background bleed around the card)
+at different thresholds, and PIL + ImageChops is close enough to either
+that running both is redundant.
+"""
+
+from __future__ import annotations
+
+from io import BytesIO
+
+from PIL import Image, ImageFilter
+
+# Downscale very large images before processing — libvips segfaults on 50MP+
+# inputs (per the script-frontend comment) and PIL is slow too. 3000px longest
+# edge is enough resolution to find card edges reliably.
+MAX_LONGEST_EDGE_PX = 3000
+
+# Gaussian blur radius before thresholding. Smooths JPEG artifacts + film
+# grain without dissolving real card edges.
+BLUR_RADIUS = 0.8
+
+# Threshold for "is this pixel background?" — values at or below this on the
+# grayscale channel are treated as background. 180 matches sharp.trim's
+# threshold (sharp uses a 0..255 scale with 180 meaning "trim anything
+# darker than this").
+DARK_THRESHOLD = 180
+
+# Border added back around the bounding box so the orient + classify stages
+# have breathing room. In pixels.
+BORDER_PX = 10
+
+
+def _maybe_downscale(img: Image.Image) -> Image.Image:
+    longest = max(img.size)
+    if longest <= MAX_LONGEST_EDGE_PX:
+        return img
+    scale = MAX_LONGEST_EDGE_PX / longest
+    new_size = (int(img.width * scale), int(img.height * scale))
+    return img.resize(new_size, Image.Resampling.LANCZOS)
+
+
+def trim(image_bytes: bytes) -> bytes | None:
+    """Run PIL-based background trim on the image.
+
+    Returns the trimmed JPEG bytes, or None if no meaningful bounding box
+    could be found (e.g. the whole image is below the dark threshold, or
+    the input is unreadable).
+    """
+    try:
+        img = Image.open(BytesIO(image_bytes))
+        img.load()
+    except Exception:  # noqa: BLE001
+        return None
+
+    img = img.convert("RGB")
+    img = _maybe_downscale(img)
+
+    blurred = img.filter(ImageFilter.GaussianBlur(radius=BLUR_RADIUS))
+    gray = blurred.convert("L")
+
+    # Create a "foreground" mask: pixels brighter than the dark threshold are
+    # content; everything else is background. getbbox() returns the bounding
+    # box of non-black pixels, so we threshold into a binary image first.
+    mask = gray.point(lambda p: 255 if p > DARK_THRESHOLD else 0, mode="L")
+    bbox = mask.getbbox()
+    if bbox is None:
+        return None
+
+    left, top, right, bottom = bbox
+    if right - left < 1 or bottom - top < 1:
+        return None
+
+    cropped = img.crop(bbox)
+
+    # Add a black border so the cropper doesn't shave off a pixel-thin slice
+    # of the card edge. `ImageChops.offset` + expand would also work; this is
+    # clearer.
+    w, h = cropped.size
+    bordered = Image.new("RGB", (w + 2 * BORDER_PX, h + 2 * BORDER_PX), color="black")
+    bordered.paste(cropped, (BORDER_PX, BORDER_PX))
+
+    out = BytesIO()
+    bordered.save(out, format="JPEG", quality=90)
+    return out.getvalue()

--- a/app/cropper/validator.py
+++ b/app/cropper/validator.py
@@ -1,0 +1,101 @@
+"""Crop-candidate validator — port of script-frontend's isPlausibleCardCrop.
+
+Rejects candidates that are too small, too off-ratio, too tiny a fraction of
+the source, or too uniform (blank / near-uniform pixels). The cascade uses
+this to short-circuit on the client's precropped upload and to gate each
+server-side crop attempt's output.
+
+Tuning knobs are module-level constants so they're easy to find and bump.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from io import BytesIO
+
+from PIL import Image, ImageStat
+
+# Standard trading-card aspect ratios (2.5" × 3.5").
+CARD_ASPECT_PORTRAIT = 2.5 / 3.5  # ≈ 0.7143
+CARD_ASPECT_LANDSCAPE = 3.5 / 2.5  # = 1.40
+ASPECT_TOLERANCE = 0.15  # ±15% — matches script-frontend's ASPECT_TOLERANCE.
+
+# Reject candidates smaller than this on either side — too small means Vision
+# OCR + Haiku classify won't have enough signal regardless of aspect.
+MIN_SIDE_PX = 300
+
+# When called with a source image, a good crop should cover a meaningful
+# fraction of the source. Rejects crops that zoomed into a tiny slice.
+MIN_AREA_FRACTION = 0.10
+
+# Standard deviation on the grayscale channel — below this is basically
+# a uniform-color image (blank paper, black backdrop, empty scanner bed).
+# Threshold picked empirically: a solid wall-colored backdrop around the
+# card body tends to produce stddev in the 20-40 range; an actual blank
+# image sits near 0.
+MIN_GRAYSCALE_STDDEV = 10.0
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    ok: bool
+    reason: str | None = None
+
+
+def is_plausible_crop(
+    image_bytes: bytes,
+    *,
+    source_area_bytes: bytes | None = None,
+) -> ValidationResult:
+    """Validate that `image_bytes` could plausibly be a trading card.
+
+    Args:
+        image_bytes: candidate crop to check.
+        source_area_bytes: if provided, an area-fraction check is applied
+            (candidate must cover MIN_AREA_FRACTION of the source's area).
+            Used when validating cascade outputs against the original upload.
+    """
+    try:
+        img = Image.open(BytesIO(image_bytes))
+        img.load()
+    except Exception as exc:  # noqa: BLE001
+        return ValidationResult(ok=False, reason=f"cannot open image: {exc}")
+
+    w, h = img.size
+    if w < MIN_SIDE_PX or h < MIN_SIDE_PX:
+        return ValidationResult(ok=False, reason=f"too small {w}x{h}")
+
+    ratio = w / h if h else 0
+    portrait_err = abs(ratio - CARD_ASPECT_PORTRAIT) / CARD_ASPECT_PORTRAIT
+    landscape_err = abs(ratio - CARD_ASPECT_LANDSCAPE) / CARD_ASPECT_LANDSCAPE
+    min_err = min(portrait_err, landscape_err)
+    if min_err > ASPECT_TOLERANCE:
+        return ValidationResult(
+            ok=False,
+            reason=f"aspect {ratio:.3f} off by {min_err * 100:.0f}%",
+        )
+
+    if source_area_bytes is not None:
+        try:
+            src = Image.open(BytesIO(source_area_bytes))
+            src_area = src.width * src.height
+            crop_area = w * h
+            if src_area > 0:
+                fraction = crop_area / src_area
+                if fraction < MIN_AREA_FRACTION:
+                    return ValidationResult(
+                        ok=False,
+                        reason=f"covers only {fraction * 100:.1f}% of source",
+                    )
+        except Exception:  # noqa: BLE001
+            pass  # can't open source → skip the area check
+
+    try:
+        gray = img.convert("L")
+        stddev = ImageStat.Stat(gray).stddev[0]
+    except Exception as exc:  # noqa: BLE001
+        return ValidationResult(ok=False, reason=f"stddev read failed: {exc}")
+    if stddev < MIN_GRAYSCALE_STDDEV:
+        return ValidationResult(ok=False, reason=f"near-uniform (stddev {stddev:.1f})")
+
+    return ValidationResult(ok=True)

--- a/app/main.py
+++ b/app/main.py
@@ -1,14 +1,25 @@
 """FastAPI entrypoint for the neonbinder-preprocess service.
 
-Slice 1 (current): `/health` + `/process`. `/process` accepts an already-
-cropped card image, runs orient + classify, and returns structured card
-fields plus the CCW rotation that was applied before classification.
+Slice 1 (shipped): `/health` + `/process`. `/process` accepts a card image
+and returns the structured orient + classify result plus the CCW rotation
+applied before classification.
 
-Slice 2 (future): `/crop-and-process` adding SAM fallback for raw photos.
+Slice 2a (this change): `/process` now optionally accepts a `precropped`
+multipart field. When present, the server validates it; if it looks like
+a plausible card, the server uses it as-is. Otherwise (or when omitted),
+the server runs a crop cascade (currently: PIL trim → passthrough) on
+the raw `image` field. The response advertises which source won via
+`cropped_source` and, when the server produced new bytes, includes them
+as base64 in `cropped_image_b64` so the client can persist the oriented
+copy without re-running anything.
+
+Future slices will add `sam` (2b) and `haiku_bbox` (2c) between pil_trim
+and passthrough in the cascade.
 """
 
 from __future__ import annotations
 
+import base64
 import hmac
 import logging
 import os
@@ -19,12 +30,13 @@ from fastapi import FastAPI, File, Header, HTTPException, UploadFile, status
 from PIL import Image
 from pydantic import BaseModel
 
+from app import cropper
 from app.classify import ClassifyError, classify_card
 from app.orient import detect_orientation
 
 logger = logging.getLogger(__name__)
 
-app = FastAPI(title="neonbinder-preprocess", version="0.1.0")
+app = FastAPI(title="neonbinder-preprocess", version="0.2.0")
 
 INTERNAL_API_KEY_ENV = "INTERNAL_API_KEY"
 MAX_IMAGE_BYTES = 32 * 1024 * 1024
@@ -34,10 +46,17 @@ ALLOWED_CONTENT_TYPES = frozenset({"image/jpeg", "image/png", "image/webp"})
 class ProcessResponse(BaseModel):
     """Response body for POST /process.
 
-    `rotation_degrees` is the CCW rotation that was applied to the image
-    before classification; clients that store the corrected image should
-    apply the same rotation to keep their copy aligned with what the model
-    actually saw.
+    `rotation_degrees` is the CCW rotation that was applied to the chosen
+    crop before classification; clients that store the corrected image
+    should apply the same rotation to keep their copy aligned with what
+    the model actually saw.
+
+    `cropped_source` tells the client which stage of the crop cascade
+    produced the working image. When it is `"precropped"` the client's
+    upload was used as-is and `cropped_image_b64` will be null (the client
+    already has the bytes on disk). For every other source, the server
+    produced new bytes and returns them base64-encoded in
+    `cropped_image_b64` so the client can persist them.
     """
 
     player: str | None
@@ -47,6 +66,8 @@ class ProcessResponse(BaseModel):
     rotation_degrees: int
     orient_confidence: float
     text_count: int
+    cropped_source: str
+    cropped_image_b64: str | None
 
 
 def _verify_internal_key(x_internal_key: str | None) -> None:
@@ -63,12 +84,33 @@ def _verify_internal_key(x_internal_key: str | None) -> None:
         )
 
 
-def _validate_content_type(content_type: str | None) -> None:
+def _validate_content_type(content_type: str | None, *, field: str) -> None:
     if (content_type or "").split(";")[0].strip() not in ALLOWED_CONTENT_TYPES:
         raise HTTPException(
             status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
-            detail=f"unsupported content-type: {content_type}",
+            detail=f"unsupported content-type for {field}: {content_type}",
         )
+
+
+async def _read_upload(
+    upload: UploadFile,
+    *,
+    field: str,
+) -> bytes:
+    """Read an UploadFile, enforcing content-type and size gates."""
+    _validate_content_type(upload.content_type, field=field)
+    data = await upload.read()
+    if not data:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"empty {field}",
+        )
+    if len(data) > MAX_IMAGE_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"{field} exceeds max size of {MAX_IMAGE_BYTES} bytes",
+        )
+    return data
 
 
 def _rotate_image_bytes(image_bytes: bytes, degrees_ccw: int) -> bytes:
@@ -90,25 +132,23 @@ def health() -> dict[str, str]:
 @app.post("/process", response_model=ProcessResponse)
 async def process(
     image: Annotated[UploadFile, File()],
+    precropped: Annotated[UploadFile | None, File()] = None,
     x_internal_key: Annotated[str | None, Header()] = None,
 ) -> ProcessResponse:
     _verify_internal_key(x_internal_key)
-    _validate_content_type(image.content_type)
 
-    image_bytes = await image.read()
-    if not image_bytes:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="empty image",
-        )
-    if len(image_bytes) > MAX_IMAGE_BYTES:
-        raise HTTPException(
-            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
-            detail=f"image exceeds max size of {MAX_IMAGE_BYTES} bytes",
-        )
+    image_bytes = await _read_upload(image, field="image")
+    precropped_bytes: bytes | None = None
+    if precropped is not None:
+        precropped_bytes = await _read_upload(precropped, field="precropped")
+
+    crop_result = cropper.crop(
+        image_bytes=image_bytes,
+        precropped_bytes=precropped_bytes,
+    )
 
     try:
-        orientation = detect_orientation(image_bytes)
+        orientation = detect_orientation(crop_result.image_bytes)
     except Exception:
         logger.exception("orient failed")
         raise HTTPException(
@@ -116,7 +156,7 @@ async def process(
             detail="orientation upstream failure",
         ) from None
 
-    rotated_bytes = _rotate_image_bytes(image_bytes, orientation.rotation_degrees)
+    rotated_bytes = _rotate_image_bytes(crop_result.image_bytes, orientation.rotation_degrees)
 
     try:
         classification = classify_card(rotated_bytes)
@@ -133,6 +173,10 @@ async def process(
             detail="classify upstream failure",
         ) from None
 
+    cropped_image_b64: str | None = None
+    if crop_result.returned_bytes_differ:
+        cropped_image_b64 = base64.b64encode(crop_result.image_bytes).decode("ascii")
+
     return ProcessResponse(
         player=classification.player,
         team=classification.team,
@@ -141,4 +185,6 @@ async def process(
         rotation_degrees=orientation.rotation_degrees,
         orient_confidence=orientation.confidence,
         text_count=orientation.text_count,
+        cropped_source=crop_result.source,
+        cropped_image_b64=cropped_image_b64,
     )

--- a/tests/integration/test_fixtures_e2e.py
+++ b/tests/integration/test_fixtures_e2e.py
@@ -62,6 +62,8 @@ def test_fixture_end_to_end(case: FixtureCase):
         "rotation_degrees",
         "orient_confidence",
         "text_count",
+        "cropped_source",
+        "cropped_image_b64",
     }, f"{case.name}: unexpected response keys {sorted(body.keys())}"
     assert body["side"] in {"front", "back"}, f"{case.name}: bad side {body['side']!r}"
     assert body["rotation_degrees"] in {
@@ -72,6 +74,19 @@ def test_fixture_end_to_end(case: FixtureCase):
     }, f"{case.name}: bad rotation {body['rotation_degrees']!r}"
     assert 0.0 <= body["orient_confidence"] <= 1.0
     assert body["text_count"] >= 0
+    # The committed fixtures are phone-camera photos (16:9 aspect) of cards,
+    # not already-tight card crops, so the cascade usually falls through to
+    # passthrough in slice 2a (no SAM yet). Just verify the source is a
+    # known label and the b64 field is consistent with it.
+    assert body["cropped_source"] in {
+        "precropped",
+        "pil_trim",
+        "passthrough",
+    }, f"{case.name}: unexpected cropped_source {body['cropped_source']!r}"
+    if body["cropped_source"] == "precropped":
+        assert (
+            body["cropped_image_b64"] is None
+        ), f"{case.name}: cropped_image_b64 should be null when source==precropped"
 
     # Sidecar-specific assertions.
     if case.rotation_degrees is not None:

--- a/tests/smoke/test_deployed.py
+++ b/tests/smoke/test_deployed.py
@@ -123,6 +123,8 @@ class TestProcessHappyPath:
             "rotation_degrees",
             "orient_confidence",
             "text_count",
+            "cropped_source",
+            "cropped_image_b64",
         }
         assert set(body.keys()) == expected_keys, f"unexpected keys {sorted(body.keys())}"
         assert body["side"] in {"front", "back"}, f"bad side {body['side']!r}"
@@ -134,3 +136,12 @@ class TestProcessHappyPath:
         }, f"bad rotation {body['rotation_degrees']!r}"
         assert 0.0 <= body["orient_confidence"] <= 1.0
         assert isinstance(body["text_count"], int) and body["text_count"] >= 0
+        # Synthetic test image is card-shaped (600x900) and noisy → passes the
+        # precropped validator. cropped_image_b64 should be null in that case.
+        assert body["cropped_source"] in {
+            "precropped",
+            "pil_trim",
+            "passthrough",
+        }, f"unexpected cropped_source {body['cropped_source']!r}"
+        if body["cropped_source"] == "precropped":
+            assert body["cropped_image_b64"] is None

--- a/tests/unit/openapi_snapshot.json
+++ b/tests/unit/openapi_snapshot.json
@@ -7,6 +7,18 @@
             "format": "binary",
             "title": "Image",
             "type": "string"
+          },
+          "precropped": {
+            "anyOf": [
+              {
+                "format": "binary",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Precropped"
           }
         },
         "required": [
@@ -29,7 +41,7 @@
         "type": "object"
       },
       "ProcessResponse": {
-        "description": "Response body for POST /process.\n\n`rotation_degrees` is the CCW rotation that was applied to the image\nbefore classification; clients that store the corrected image should\napply the same rotation to keep their copy aligned with what the model\nactually saw.",
+        "description": "Response body for POST /process.\n\n`rotation_degrees` is the CCW rotation that was applied to the chosen\ncrop before classification; clients that store the corrected image\nshould apply the same rotation to keep their copy aligned with what\nthe model actually saw.\n\n`cropped_source` tells the client which stage of the crop cascade\nproduced the working image. When it is `\"precropped\"` the client's\nupload was used as-is and `cropped_image_b64` will be null (the client\nalready has the bytes on disk). For every other source, the server\nproduced new bytes and returns them base64-encoded in\n`cropped_image_b64` so the client can persist them.",
         "properties": {
           "card_number": {
             "anyOf": [
@@ -41,6 +53,21 @@
               }
             ],
             "title": "Card Number"
+          },
+          "cropped_image_b64": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cropped Image B64"
+          },
+          "cropped_source": {
+            "title": "Cropped Source",
+            "type": "string"
           },
           "orient_confidence": {
             "title": "Orient Confidence",
@@ -88,7 +115,9 @@
           "side",
           "rotation_degrees",
           "orient_confidence",
-          "text_count"
+          "text_count",
+          "cropped_source",
+          "cropped_image_b64"
         ],
         "title": "ProcessResponse",
         "type": "object"
@@ -130,7 +159,7 @@
   },
   "info": {
     "title": "neonbinder-preprocess",
-    "version": "0.1.0"
+    "version": "0.2.0"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/tests/unit/test_cropper_cascade.py
+++ b/tests/unit/test_cropper_cascade.py
@@ -1,0 +1,119 @@
+"""Unit tests for app.cropper.crop — the cascade orchestrator.
+
+Exercises each branch of the waterfall: precropped-passes, precropped-fails
+(falls through to pil_trim), no-precropped (image used as candidate),
+pil_trim produces result, pil_trim fails → passthrough.
+"""
+
+from __future__ import annotations
+
+import io
+
+from PIL import Image
+
+from app.cropper import CropResult, crop
+
+
+def _card_jpeg(*, size: tuple[int, int] = (500, 700)) -> bytes:
+    """A plausible card: card-sized, card-shaped, noisy (not blank)."""
+    import random
+
+    rng = random.Random(size[0] * 31 + size[1])
+    raw = bytes(rng.randint(0, 255) for _ in range(size[0] * size[1] * 3))
+    img = Image.frombytes("RGB", size, raw)
+    out = io.BytesIO()
+    img.save(out, format="JPEG", quality=85)
+    return out.getvalue()
+
+
+def _tiny_jpeg() -> bytes:
+    """Too small to pass the validator — forces cascade fallthrough."""
+    return _card_jpeg(size=(100, 140))
+
+
+class TestCascade:
+    def test_precropped_passes_validation_is_used(self):
+        image_bytes = _card_jpeg(size=(1200, 1600))  # raw
+        precropped = _card_jpeg(size=(500, 700))  # a good crop
+
+        result = crop(image_bytes=image_bytes, precropped_bytes=precropped)
+
+        assert result.source == "precropped"
+        assert result.image_bytes == precropped
+        assert result.returned_bytes_differ is False
+
+    def test_missing_precropped_uses_image_when_image_validates(self):
+        # Slice-1 compat: no precropped, and the image itself looks like a
+        # card (already pre-cropped client-side). Cascade should recognize
+        # it as the precropped candidate and use it without trimming.
+        image_bytes = _card_jpeg(size=(500, 700))
+
+        result = crop(image_bytes=image_bytes, precropped_bytes=None)
+
+        assert result.source == "precropped"
+        assert result.image_bytes == image_bytes
+        assert result.returned_bytes_differ is False
+
+    def test_invalid_precropped_falls_through_to_pil_trim(self, monkeypatch):
+        # Force pil_trim to return a known good crop so we can detect that
+        # stage ran instead of skipping straight to passthrough.
+        synthetic_trimmed = _card_jpeg(size=(500, 700))
+        monkeypatch.setattr("app.cropper.pil_trim.trim", lambda _b: synthetic_trimmed)
+
+        # The "precropped" is too small → validator rejects, cascade advances.
+        image_bytes = _card_jpeg(size=(1200, 1600))
+        bad_precropped = _tiny_jpeg()
+
+        result = crop(image_bytes=image_bytes, precropped_bytes=bad_precropped)
+
+        assert result.source == "pil_trim"
+        assert result.image_bytes == synthetic_trimmed
+        assert result.returned_bytes_differ is True
+
+    def test_pil_trim_output_rejected_falls_through_to_passthrough(self, monkeypatch):
+        # pil_trim returns something, but it fails validation (too small).
+        # Cascade should fall through to passthrough.
+        monkeypatch.setattr("app.cropper.pil_trim.trim", lambda _b: _tiny_jpeg())
+
+        image_bytes = _card_jpeg(size=(1200, 1600))
+        bad_precropped = _tiny_jpeg()
+
+        result = crop(image_bytes=image_bytes, precropped_bytes=bad_precropped)
+
+        assert result.source == "passthrough"
+        assert result.image_bytes == image_bytes
+        assert result.returned_bytes_differ is False
+
+    def test_pil_trim_returns_none_falls_through_to_passthrough(self, monkeypatch):
+        monkeypatch.setattr("app.cropper.pil_trim.trim", lambda _b: None)
+
+        image_bytes = _card_jpeg(size=(1200, 1600))
+        bad_precropped = _tiny_jpeg()
+
+        result = crop(image_bytes=image_bytes, precropped_bytes=bad_precropped)
+
+        assert result.source == "passthrough"
+        assert result.image_bytes == image_bytes
+
+    def test_pil_trim_raises_falls_through_to_passthrough(self, monkeypatch):
+        def _boom(_b):
+            raise RuntimeError("pil_trim exploded")
+
+        monkeypatch.setattr("app.cropper.pil_trim.trim", _boom)
+
+        image_bytes = _card_jpeg(size=(1200, 1600))
+        bad_precropped = _tiny_jpeg()
+
+        result = crop(image_bytes=image_bytes, precropped_bytes=bad_precropped)
+
+        # Exception in a strategy must not kill the cascade — fall through.
+        assert result.source == "passthrough"
+        assert result.image_bytes == image_bytes
+
+    def test_crop_result_is_immutable_dataclass(self):
+        r = CropResult(image_bytes=b"x", source="precropped", returned_bytes_differ=False)
+        try:
+            r.source = "other"  # type: ignore[misc]
+        except Exception:
+            return
+        raise AssertionError("CropResult should be frozen")

--- a/tests/unit/test_cropper_pil_trim.py
+++ b/tests/unit/test_cropper_pil_trim.py
@@ -1,0 +1,74 @@
+"""Unit tests for app.cropper.pil_trim.
+
+Focuses on the observable behavior: given a card-on-dark-background input,
+the trim extracts the card region and returns JPEG bytes with reasonable
+dimensions. Precise pixel-exact matching against a reference image is
+brittle, so we assert shape properties instead.
+"""
+
+from __future__ import annotations
+
+import io
+
+from PIL import Image, ImageDraw
+
+from app.cropper.pil_trim import BORDER_PX, MAX_LONGEST_EDGE_PX, trim
+
+
+def _card_on_dark_background(
+    *,
+    canvas_size: tuple[int, int] = (1200, 1600),
+    card_box: tuple[int, int, int, int] = (200, 300, 1000, 1400),
+    card_color: str = "white",
+) -> bytes:
+    """Render a light card on a black canvas.
+
+    Returns JPEG bytes the trim can meaningfully cut.
+    """
+    img = Image.new("RGB", canvas_size, color="black")
+    draw = ImageDraw.Draw(img)
+    draw.rectangle(card_box, fill=card_color)
+    out = io.BytesIO()
+    img.save(out, format="JPEG", quality=90)
+    return out.getvalue()
+
+
+class TestTrim:
+    def test_returns_bytes_for_card_on_background(self):
+        result = trim(_card_on_dark_background())
+        assert result is not None
+        # Round-trip through PIL to confirm it decoded as an image.
+        with Image.open(io.BytesIO(result)) as out:
+            assert out.size[0] > 0 and out.size[1] > 0
+
+    def test_output_includes_border(self):
+        # Card is 800 wide × 1100 tall; output should be roughly that plus
+        # 2*BORDER_PX on each axis.
+        result = trim(_card_on_dark_background())
+        assert result is not None
+        with Image.open(io.BytesIO(result)) as out:
+            w, h = out.size
+            assert 800 <= w <= 800 + 2 * BORDER_PX + 10
+            assert 1100 <= h <= 1100 + 2 * BORDER_PX + 10
+
+    def test_downscales_very_large_inputs(self):
+        # Construct an image well over the downscale threshold; verify the
+        # output doesn't exceed the cap on either dimension.
+        big = _card_on_dark_background(
+            canvas_size=(5000, 6000),
+            card_box=(800, 1000, 4200, 5000),
+        )
+        result = trim(big)
+        assert result is not None
+        with Image.open(io.BytesIO(result)) as out:
+            assert max(out.size) <= MAX_LONGEST_EDGE_PX
+
+    def test_returns_none_for_all_black_image(self):
+        img = Image.new("RGB", (1000, 1400), color="black")
+        buf = io.BytesIO()
+        img.save(buf, format="JPEG", quality=90)
+        # Nothing above the threshold → getbbox returns None.
+        assert trim(buf.getvalue()) is None
+
+    def test_returns_none_for_unreadable_bytes(self):
+        assert trim(b"definitely not an image") is None

--- a/tests/unit/test_cropper_validator.py
+++ b/tests/unit/test_cropper_validator.py
@@ -1,0 +1,120 @@
+"""Unit tests for app.cropper.validator.
+
+Covers each rejection path (too small, bad aspect, area fraction, blank)
+and the happy path. Fixtures are generated in-memory with PIL so tests
+are self-contained.
+"""
+
+from __future__ import annotations
+
+import io
+import random
+
+from PIL import Image
+
+from app.cropper.validator import (
+    ASPECT_TOLERANCE,
+    CARD_ASPECT_PORTRAIT,
+    MIN_SIDE_PX,
+    is_plausible_crop,
+)
+
+
+def _jpeg_of_size(w: int, h: int, *, color: str = "white", noise: bool = True) -> bytes:
+    """Emit a JPEG of the requested size.
+
+    Without `noise`, the image is a uniform color — useful for testing the
+    blank-detection path. With `noise`, random pixel values make stddev
+    comfortably exceed the blank threshold.
+    """
+    if noise:
+        rng = random.Random(42)
+        raw = bytes(rng.randint(0, 255) for _ in range(w * h * 3))
+        img = Image.frombytes("RGB", (w, h), raw)
+    else:
+        img = Image.new("RGB", (w, h), color=color)
+    out = io.BytesIO()
+    img.save(out, format="JPEG", quality=85)
+    return out.getvalue()
+
+
+def _portrait_card(scale: int = 1) -> bytes:
+    # Standard trading-card portrait ratio: 2.5:3.5.
+    return _jpeg_of_size(500 * scale, 700 * scale)
+
+
+def _landscape_card(scale: int = 1) -> bytes:
+    return _jpeg_of_size(700 * scale, 500 * scale)
+
+
+class TestPlausibleCrop:
+    def test_portrait_card_passes(self):
+        result = is_plausible_crop(_portrait_card())
+        assert result.ok, result.reason
+
+    def test_landscape_card_passes(self):
+        result = is_plausible_crop(_landscape_card())
+        assert result.ok, result.reason
+
+    def test_too_small_rejected(self):
+        tiny = _jpeg_of_size(MIN_SIDE_PX - 50, MIN_SIDE_PX - 50)
+        result = is_plausible_crop(tiny)
+        assert not result.ok
+        assert "too small" in (result.reason or "")
+
+    def test_wrong_aspect_rejected(self):
+        # Square image — ~40% off both portrait and landscape ratios.
+        square = _jpeg_of_size(500, 500)
+        result = is_plausible_crop(square)
+        assert not result.ok
+        assert "aspect" in (result.reason or "")
+
+    def test_aspect_just_inside_tolerance_passes(self):
+        # 15% tolerance means we accept up to ±15% of 0.714 → 0.607 to 0.821.
+        # Construct 450x700 → ratio 0.643 → ~10% off portrait, inside tol.
+        inside = _jpeg_of_size(450, 700)
+        result = is_plausible_crop(inside)
+        assert result.ok, result.reason
+
+    def test_aspect_just_outside_tolerance_rejected(self):
+        # 350x700 → ratio 0.5 → 30% off portrait, outside tolerance.
+        outside = _jpeg_of_size(350, 700)
+        result = is_plausible_crop(outside)
+        assert not result.ok
+
+    def test_blank_image_rejected(self):
+        # Uniform-white image — stddev ~= 0.
+        blank = _jpeg_of_size(500, 700, color="white", noise=False)
+        result = is_plausible_crop(blank)
+        assert not result.ok
+        assert "near-uniform" in (result.reason or "")
+
+    def test_unreadable_bytes_rejected(self):
+        result = is_plausible_crop(b"not an image at all")
+        assert not result.ok
+        assert "cannot open" in (result.reason or "")
+
+    def test_area_fraction_gate(self):
+        # 500x700 card out of a 2000x2800 source → ~6% — rejected (< 10%).
+        # Kept deliberately small to avoid burning seconds on random-byte
+        # generation for a test whose point is the fraction math, not size.
+        source = _jpeg_of_size(2000, 2800)
+        small_crop = _portrait_card()  # 500x700
+        result = is_plausible_crop(small_crop, source_area_bytes=source)
+        assert not result.ok
+        assert "covers only" in (result.reason or "")
+
+    def test_area_fraction_passes_when_large_enough(self):
+        # 500x700 / 1000x1400 = 25% → passes.
+        source = _jpeg_of_size(1000, 1400)
+        crop = _portrait_card()
+        result = is_plausible_crop(crop, source_area_bytes=source)
+        assert result.ok, result.reason
+
+    def test_tolerance_sanity(self):
+        # Tolerance is defined at module level; if someone changes it, the
+        # inside/outside tests above might need updates. This test protects
+        # against accidental changes to ASPECT_TOLERANCE that break the
+        # public meaning of "plausible".
+        assert 0.05 <= ASPECT_TOLERANCE <= 0.25
+        assert 0.6 < CARD_ASPECT_PORTRAIT < 0.8

--- a/tests/unit/test_process_route.py
+++ b/tests/unit/test_process_route.py
@@ -208,6 +208,11 @@ class TestHappyPath:
             "rotation_degrees": 0,
             "orient_confidence": 0.9,
             "text_count": 12,
+            # The 8x8 fixture is too small to pass the validator, so the
+            # cascade falls through to passthrough. Bytes returned ==
+            # bytes uploaded, so no b64 payload.
+            "cropped_source": "passthrough",
+            "cropped_image_b64": None,
         }
 
     def test_accepts_png_content_type(self, monkeypatch):
@@ -252,3 +257,133 @@ class TestHappyPath:
         )
 
         assert classify_inputs[0] == original
+
+
+class TestPrecroppedField:
+    """Coverage for the optional `precropped` multipart field added in slice 2a."""
+
+    @staticmethod
+    def _card_bytes(size: tuple[int, int] = (500, 700)) -> bytes:
+        import random
+
+        rng = random.Random(size[0] + size[1])
+        raw = bytes(rng.randint(0, 255) for _ in range(size[0] * size[1] * 3))
+        out = io.BytesIO()
+        Image.frombytes("RGB", size, raw).save(out, format="JPEG", quality=85)
+        return out.getvalue()
+
+    def test_valid_precropped_wins_cascade(self, monkeypatch):
+        _stub_orient(monkeypatch)
+        classify_inputs = _stub_classify(monkeypatch)
+
+        precropped = self._card_bytes()
+        response = client.post(
+            "/process",
+            headers={"x-internal-key": "test-key"},
+            files={
+                "image": ("raw.jpg", _jpeg((40, 20)), "image/jpeg"),
+                "precropped": ("crop.jpg", precropped, "image/jpeg"),
+            },
+        )
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["cropped_source"] == "precropped"
+        # When source == precropped, client already has the bytes — no b64.
+        assert body["cropped_image_b64"] is None
+        # Classify should see the precropped bytes (no trimming) before rotation.
+        assert len(classify_inputs) == 1
+
+    def test_precropped_wrong_content_type_returns_415(self, monkeypatch):
+        _stub_orient(monkeypatch)
+        _stub_classify(monkeypatch)
+
+        response = client.post(
+            "/process",
+            headers={"x-internal-key": "test-key"},
+            files={
+                "image": ("raw.jpg", _jpeg(), "image/jpeg"),
+                "precropped": ("crop.txt", b"not an image", "text/plain"),
+            },
+        )
+        assert response.status_code == 415
+        assert "precropped" in response.json()["detail"]
+
+    def test_empty_precropped_returns_400(self, monkeypatch):
+        _stub_orient(monkeypatch)
+        _stub_classify(monkeypatch)
+
+        response = client.post(
+            "/process",
+            headers={"x-internal-key": "test-key"},
+            files={
+                "image": ("raw.jpg", _jpeg(), "image/jpeg"),
+                "precropped": ("crop.jpg", b"", "image/jpeg"),
+            },
+        )
+        assert response.status_code == 400
+        assert "empty precropped" in response.json()["detail"]
+
+    def test_oversized_precropped_returns_413(self, monkeypatch):
+        from app.main import MAX_IMAGE_BYTES
+
+        _stub_orient(monkeypatch)
+        _stub_classify(monkeypatch)
+
+        response = client.post(
+            "/process",
+            headers={"x-internal-key": "test-key"},
+            files={
+                "image": ("raw.jpg", _jpeg(), "image/jpeg"),
+                "precropped": ("crop.jpg", b"x" * (MAX_IMAGE_BYTES + 1), "image/jpeg"),
+            },
+        )
+        assert response.status_code == 413
+
+    def test_invalid_precropped_falls_through_to_cascade(self, monkeypatch):
+        """A tiny precropped fails the validator; cascade runs on image bytes."""
+        _stub_orient(monkeypatch)
+        _stub_classify(monkeypatch)
+
+        response = client.post(
+            "/process",
+            headers={"x-internal-key": "test-key"},
+            files={
+                "image": ("raw.jpg", _jpeg((40, 20)), "image/jpeg"),
+                # 100x100 passes content-type but too-small to be a card.
+                "precropped": ("crop.jpg", _jpeg((100, 100)), "image/jpeg"),
+            },
+        )
+        assert response.status_code == 200
+        body = response.json()
+        # With such a small image and precropped both failing, cascade should
+        # reach passthrough (pil_trim on a 40x20 image returns junk and is
+        # rejected by validator too).
+        assert body["cropped_source"] == "passthrough"
+        assert body["cropped_image_b64"] is None
+
+    def test_cascade_produced_bytes_are_returned_as_b64(self, monkeypatch):
+        """When source != precropped and cascade produced new bytes, they're b64-encoded."""
+        _stub_orient(monkeypatch)
+        _stub_classify(monkeypatch)
+
+        # Force pil_trim to return known good card-shaped bytes. The cascade
+        # will pick it and returned_bytes_differ will be True.
+        good_crop = self._card_bytes()
+        monkeypatch.setattr("app.cropper.pil_trim.trim", lambda _b: good_crop)
+
+        response = client.post(
+            "/process",
+            headers={"x-internal-key": "test-key"},
+            files={
+                "image": ("raw.jpg", _jpeg((40, 20)), "image/jpeg"),
+                "precropped": ("crop.jpg", _jpeg((100, 100)), "image/jpeg"),
+            },
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["cropped_source"] == "pil_trim"
+        assert body["cropped_image_b64"] is not None
+        import base64
+
+        assert base64.b64decode(body["cropped_image_b64"]) == good_crop


### PR DESCRIPTION
## Summary

Turns `/process` into a single-endpoint image pipeline. Adds optional `precropped` multipart field; server validates + uses it as-is if plausible, otherwise runs a server-side crop cascade on the raw `image`. Prepares for slices 2b (SAM) and 2c (haiku_bbox) which plug in between pil_trim and passthrough.

## API changes

```
POST /process
  image:      required
  precropped: optional (new)

Response adds:
  cropped_source: "precropped" | "pil_trim" | "passthrough"
  cropped_image_b64: string | null  # null when source == "precropped"
```

Backward-compat preserved: when `precropped` is absent, the server treats `image` as the candidate. Slice-1 callers (script-frontend after PR at edvedafi/cardlister-server-railway#feat/preprocess-local-wiring) continue working; their already-cropped card images hit the validator and short-circuit on `precropped`.

## Cascade

1. **Validate candidate** (precropped, or image if no precropped). Min side ≥ 300px, aspect ratio within ±15% of 0.71 / 1.40, grayscale stddev ≥ 10. Port of `isPlausibleCardCrop` in `imageProcessor.js:26-47`. If passes: use it, `source="precropped"`.
2. **PIL trim** — port of `sharp.trim`: Gaussian blur → threshold dark pixels → `getbbox()` → expand border. If output passes validator: use it, `source="pil_trim"`.
3. **Passthrough** — return the original image unchanged. `source="passthrough"`.

## Out of scope (future slices)

- **Slice 2b**: SAM semantic segmentation. Adds torch + 375MB weights, image size ~500MB → ~3.5GB, cold start ~60-90s. Inserted between pil_trim and passthrough.
- **Slice 2c**: Anthropic Haiku bbox. Cheap; reuses existing SDK. Order within cascade TBD based on cost vs. accuracy.
- **Dropped** from the original script-frontend waterfall: `CardCropper.rotate` / `CardCropper` (macOS Swift, stays client-side), `sharp.extract` (needs manual listing coords), `magick.fuzz.trim` (requires +200MB ImageMagick install, overlaps pil_trim), `manual` (interactive), `Ollama` (replaced by `haiku_bbox` in 2c).

## Tests

- **11 validator unit tests** — each rejection branch + happy path, aspect tolerance sanity, area-fraction gate
- **5 pil_trim tests** — card-on-dark success, downscale of oversized inputs, all-black returns None, unreadable bytes handled
- **7 cascade orchestration tests** — each branch with monkeypatched pil_trim
- **6 new /process route tests** covering the `precropped` field (valid, wrong content-type, empty, oversized, invalid-falls-through, cascade-bytes-returned-as-b64)
- Existing tests updated for the 9-field response
- Integration shape check expanded; the 3 committed fixtures now produce `source="passthrough"` (they're phone-camera 16:9 photos, not card-ratio crops — functionally identical to pre-2a)
- OpenAPI snapshot regenerated

74 unit + 3 integration tests, 97.4% coverage.

## Test plan

- [ ] `test` + `deploy-preview` + `preview-smoke` green.
- [ ] Merge → prod pipeline green.
- [ ] Against deployed dev: send a Swift-cropped card image with `precropped` field — response has `cropped_source: "precropped"`, `cropped_image_b64: null`.
- [ ] Against deployed dev: send only `image` (slice-1 shape) — response still works, classification unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)