### PR TITLE
feat(slice-2c): haiku_bbox crop fallback

### DIFF
--- a/app/cropper/__init__.py
+++ b/app/cropper/__init__.py
@@ -49,7 +49,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 from app.classify import ClassifyResult, classify_card
-from app.cropper import pil_trim, sam
+from app.cropper import haiku_bbox, pil_trim, sam
 from app.cropper._utils import rotate_image_bytes
 from app.cropper.validator import is_plausible_crop
 from app.orient import OrientationResult, detect_orientation
@@ -76,7 +76,7 @@ CropStrategy = Callable[[bytes], bytes | None]
 _STRATEGIES: list[tuple[str, object, str]] = [
     ("pil_trim", pil_trim, "trim"),
     ("sam", sam, "sam_crop"),
-    # TODO(slice-2c): ("haiku_bbox", haiku_bbox, "crop"),
+    ("haiku_bbox", haiku_bbox, "haiku_bbox_crop"),
 ]
 
 

--- a/app/cropper/haiku_bbox.py
+++ b/app/cropper/haiku_bbox.py
@@ -1,0 +1,207 @@
+"""Haiku-based bounding-box crop.
+
+When SAM fails to find a plausible card mask — usually unusual card shapes,
+heavy occlusion, or backgrounds where SAM's center-biased probes miss the
+card — this stage asks Claude Haiku to locate the card and crops via PIL.
+Cheap (~$0.0005 per call), no additional runtime deps (anthropic SDK is
+already loaded for classify).
+
+Public API: `haiku_bbox_crop(image_bytes) -> bytes | None`. Returns JPEG
+bytes of the cropped region, or None if Haiku couldn't identify a card.
+
+Implementation note: the image we feed Haiku goes through the same
+downscale step as the classify call (`_prepare_for_anthropic` — ≤3.5 MB
+raw to stay under Anthropic's 5 MB base64 cap). Haiku's bounding box
+therefore lives in the downscaled coordinate system; we rescale back to
+the original dimensions before cropping so the output preserves full
+resolution for downstream orient + classify.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+from io import BytesIO
+
+import anthropic
+from PIL import Image
+
+from app.classify import _prepare_for_anthropic
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL = "claude-haiku-4-5-20251001"
+MAX_TOKENS = 200
+TEMPERATURE = 0.0
+
+PROMPT = """You are looking at a photo that contains a single trading card.
+
+Return the bounding box of the card as a JSON object with integer pixel
+coordinates relative to the input image dimensions:
+
+  {"x": <left>, "y": <top>, "w": <width>, "h": <height>}
+
+The box should tightly enclose the card INCLUDING its border but EXCLUDING
+the background / desk / hands / etc.
+
+If no card is clearly visible, or you are uncertain about the bounds,
+return {"x": 0, "y": 0, "w": 0, "h": 0}.
+
+Respond with ONLY the JSON object. No preamble, no markdown, no code fences."""
+
+
+def _strip_code_fences(text: str) -> str:
+    stripped = text.strip()
+    if stripped.startswith("```"):
+        stripped = stripped.split("\n", 1)[1] if "\n" in stripped else stripped[3:]
+        if stripped.rstrip().endswith("```"):
+            stripped = stripped.rstrip()[:-3]
+    return stripped.strip()
+
+
+def _parse_bbox(text: str) -> tuple[int, int, int, int] | None:
+    """Parse Haiku's JSON response into (x, y, w, h). None on any failure."""
+    try:
+        data = json.loads(_strip_code_fences(text))
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    try:
+        x = int(data["x"])
+        y = int(data["y"])
+        w = int(data["w"])
+        h = int(data["h"])
+    except (KeyError, ValueError, TypeError):
+        return None
+    if w <= 0 or h <= 0:
+        return None
+    return x, y, w, h
+
+
+def _call_haiku(
+    client: anthropic.Anthropic,
+    *,
+    payload: bytes,
+    media_type: str,
+    model: str,
+) -> str:
+    b64 = base64.b64encode(payload).decode("ascii")
+    response = client.messages.create(
+        model=model,
+        max_tokens=MAX_TOKENS,
+        temperature=TEMPERATURE,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "base64",
+                            "media_type": media_type,
+                            "data": b64,
+                        },
+                    },
+                    {"type": "text", "text": PROMPT},
+                ],
+            }
+        ],
+    )
+    if not response.content:
+        return ""
+    block = response.content[0]
+    return getattr(block, "text", "") or ""
+
+
+def _rescale_bbox(
+    bbox: tuple[int, int, int, int],
+    *,
+    downscaled_size: tuple[int, int],
+    original_size: tuple[int, int],
+) -> tuple[int, int, int, int] | None:
+    """Rescale bbox from downscaled space to original, clamp to image bounds."""
+    dx, dy, dw, dh = bbox
+    ddw, ddh = downscaled_size
+    ow, oh = original_size
+    if ddw <= 0 or ddh <= 0:
+        return None
+
+    scale_x = ow / ddw
+    scale_y = oh / ddh
+    x = max(0, int(dx * scale_x))
+    y = max(0, int(dy * scale_y))
+    w = max(1, int(dw * scale_x))
+    h = max(1, int(dh * scale_y))
+    if x + w > ow:
+        w = ow - x
+    if y + h > oh:
+        h = oh - y
+    if w <= 0 or h <= 0:
+        return None
+    return x, y, w, h
+
+
+def haiku_bbox_crop(
+    image_bytes: bytes,
+    *,
+    client: anthropic.Anthropic | None = None,
+    model: str = DEFAULT_MODEL,
+) -> bytes | None:
+    """Crop the card from `image_bytes` using Haiku's bounding box.
+
+    Returns JPEG bytes of the cropped region, or None if Haiku couldn't
+    locate a card or any step failed. The cascade's text-count + validator
+    gates still apply downstream.
+    """
+    if not image_bytes:
+        return None
+
+    ai_client = client or anthropic.Anthropic()
+
+    try:
+        payload, media_type = _prepare_for_anthropic(image_bytes)
+    except Exception:
+        logger.exception("haiku_bbox: _prepare_for_anthropic failed")
+        return None
+
+    try:
+        text = _call_haiku(ai_client, payload=payload, media_type=media_type, model=model)
+    except Exception:
+        logger.exception("haiku_bbox: Haiku call failed")
+        return None
+
+    bbox = _parse_bbox(text)
+    if bbox is None:
+        logger.info("haiku_bbox: no valid bbox in response %r", text[:200])
+        return None
+
+    try:
+        with Image.open(BytesIO(payload)) as downscaled:
+            downscaled_size = downscaled.size
+        with Image.open(BytesIO(image_bytes)) as original:
+            original_size = original.size
+    except Exception:
+        logger.exception("haiku_bbox: failed to read image dimensions")
+        return None
+
+    scaled = _rescale_bbox(
+        bbox,
+        downscaled_size=downscaled_size,
+        original_size=original_size,
+    )
+    if scaled is None:
+        logger.info("haiku_bbox: rescale produced empty bbox")
+        return None
+
+    x, y, w, h = scaled
+    try:
+        with Image.open(BytesIO(image_bytes)) as img:
+            cropped = img.convert("RGB").crop((x, y, x + w, y + h))
+            out = BytesIO()
+            cropped.save(out, format="JPEG", quality=90)
+            return out.getvalue()
+    except Exception:
+        logger.exception("haiku_bbox: PIL crop failed")
+        return None

--- a/tests/unit/test_cropper_cascade.py
+++ b/tests/unit/test_cropper_cascade.py
@@ -278,13 +278,75 @@ class TestSamStage:
         assert result.source == "sam"
         assert result.classification.players == []
 
-    def test_sam_raises_falls_through_to_passthrough(self, monkeypatch, stub_orient, stub_classify):
+    def test_sam_raises_falls_through_to_haiku_bbox(self, monkeypatch, stub_orient, stub_classify):
+        """pil_trim empty + SAM raises → cascade tries haiku_bbox next."""
+        good = _card_jpeg(size=(500, 700))
         monkeypatch.setattr("app.cropper.pil_trim.trim", lambda _b: None)
 
         def _boom(_b):
             raise RuntimeError("SAM crashed")
 
         monkeypatch.setattr("app.cropper.sam.sam_crop", _boom)
+        monkeypatch.setattr("app.cropper.haiku_bbox.haiku_bbox_crop", lambda _b: good)
+
+        stub_orient()
+        stub_classify(_classify())
+
+        image = _card_jpeg(size=(1200, 1600))
+        bad_precropped = _tiny_jpeg()
+
+        result = crop(image_bytes=image, precropped_bytes=bad_precropped)
+
+        assert result.source == "haiku_bbox"
+
+
+class TestHaikuBboxStage:
+    def test_haiku_bbox_wins_when_earlier_stages_fail(
+        self, monkeypatch, stub_orient, stub_classify
+    ):
+        good = _card_jpeg(size=(500, 700))
+        monkeypatch.setattr("app.cropper.pil_trim.trim", lambda _b: None)
+        monkeypatch.setattr("app.cropper.sam.sam_crop", lambda _b: None)
+        monkeypatch.setattr("app.cropper.haiku_bbox.haiku_bbox_crop", lambda _b: good)
+
+        stub_orient()
+        stub_classify(_classify())
+
+        image = _card_jpeg(size=(1200, 1600))
+        bad_precropped = _tiny_jpeg()
+
+        result = crop(image_bytes=image, precropped_bytes=bad_precropped)
+
+        assert result.source == "haiku_bbox"
+        assert result.returned_bytes_differ is True
+
+    def test_haiku_bbox_empty_falls_through_to_passthrough(
+        self, monkeypatch, stub_orient, stub_classify
+    ):
+        monkeypatch.setattr("app.cropper.pil_trim.trim", lambda _b: None)
+        monkeypatch.setattr("app.cropper.sam.sam_crop", lambda _b: None)
+        monkeypatch.setattr("app.cropper.haiku_bbox.haiku_bbox_crop", lambda _b: None)
+
+        stub_orient()
+        stub_classify(_classify())
+
+        image = _card_jpeg(size=(1200, 1600))
+        bad_precropped = _tiny_jpeg()
+
+        result = crop(image_bytes=image, precropped_bytes=bad_precropped)
+
+        assert result.source == "passthrough"
+
+    def test_haiku_bbox_raises_falls_through_to_passthrough(
+        self, monkeypatch, stub_orient, stub_classify
+    ):
+        monkeypatch.setattr("app.cropper.pil_trim.trim", lambda _b: None)
+        monkeypatch.setattr("app.cropper.sam.sam_crop", lambda _b: None)
+
+        def _boom(_b):
+            raise RuntimeError("anthropic down")
+
+        monkeypatch.setattr("app.cropper.haiku_bbox.haiku_bbox_crop", _boom)
 
         stub_orient()
         stub_classify(_classify())

--- a/tests/unit/test_cropper_haiku_bbox.py
+++ b/tests/unit/test_cropper_haiku_bbox.py
@@ -1,0 +1,191 @@
+"""Unit tests for app.cropper.haiku_bbox.
+
+Anthropic SDK is mocked — no real Haiku calls. Covers parse helpers, the
+downscale-coord rescaling, the crop step, and the error paths that must
+return None rather than raise.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from PIL import Image
+
+from app.cropper.haiku_bbox import (
+    _parse_bbox,
+    _rescale_bbox,
+    _strip_code_fences,
+    haiku_bbox_crop,
+)
+
+
+def _response_with_text(text: str) -> SimpleNamespace:
+    return SimpleNamespace(content=[SimpleNamespace(text=text)])
+
+
+def _empty_response() -> SimpleNamespace:
+    return SimpleNamespace(content=[])
+
+
+def _mock_client(*responses: SimpleNamespace) -> MagicMock:
+    client = MagicMock()
+    client.messages.create.side_effect = list(responses)
+    return client
+
+
+def _png_bytes(size: tuple[int, int] = (1200, 1600), color: str = "white") -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", size, color=color).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _jpeg_bytes(size: tuple[int, int] = (1200, 1600), color: str = "white") -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", size, color=color).save(buf, format="JPEG", quality=85)
+    return buf.getvalue()
+
+
+class TestParseBbox:
+    def test_parses_plain_json(self):
+        assert _parse_bbox('{"x": 10, "y": 20, "w": 300, "h": 420}') == (10, 20, 300, 420)
+
+    def test_strips_code_fences(self):
+        assert _parse_bbox('```json\n{"x": 0, "y": 0, "w": 100, "h": 140}\n```') == (
+            0,
+            0,
+            100,
+            140,
+        )
+
+    def test_rejects_zero_width(self):
+        assert _parse_bbox('{"x": 0, "y": 0, "w": 0, "h": 100}') is None
+
+    def test_rejects_negative_values(self):
+        assert _parse_bbox('{"x": 0, "y": 0, "w": -5, "h": 100}') is None
+
+    def test_rejects_missing_key(self):
+        assert _parse_bbox('{"x": 0, "y": 0, "w": 100}') is None
+
+    def test_rejects_non_dict_json(self):
+        assert _parse_bbox("[1, 2, 3]") is None
+
+    def test_rejects_invalid_json(self):
+        assert _parse_bbox("not json at all") is None
+
+
+class TestStripCodeFences:
+    def test_no_fence(self):
+        assert _strip_code_fences('{"a":1}') == '{"a":1}'
+
+    def test_json_fence(self):
+        assert _strip_code_fences('```json\n{"a":1}\n```') == '{"a":1}'
+
+    def test_bare_fence(self):
+        assert _strip_code_fences('```\n{"a":1}\n```') == '{"a":1}'
+
+
+class TestRescaleBbox:
+    def test_identity_when_sizes_match(self):
+        result = _rescale_bbox(
+            (10, 20, 100, 140),
+            downscaled_size=(1200, 1600),
+            original_size=(1200, 1600),
+        )
+        assert result == (10, 20, 100, 140)
+
+    def test_scales_up_to_original_dimensions(self):
+        # Downscaled 600x800, original 1200x1600 → 2x in each direction.
+        result = _rescale_bbox(
+            (50, 100, 300, 400),
+            downscaled_size=(600, 800),
+            original_size=(1200, 1600),
+        )
+        assert result == (100, 200, 600, 800)
+
+    def test_clamps_bbox_that_overflows(self):
+        # Haiku may return bounds past the image edge; we clamp to stay inside.
+        result = _rescale_bbox(
+            (500, 500, 200, 200),
+            downscaled_size=(600, 600),
+            original_size=(600, 600),
+        )
+        assert result == (500, 500, 100, 100)
+
+    def test_returns_none_when_downscaled_size_invalid(self):
+        assert (
+            _rescale_bbox(
+                (0, 0, 100, 100),
+                downscaled_size=(0, 0),
+                original_size=(1000, 1000),
+            )
+            is None
+        )
+
+
+class TestHaikuBboxCrop:
+    def test_happy_path_returns_cropped_bytes(self):
+        # Small source so _prepare_for_anthropic passes it through unchanged —
+        # bbox coordinates land in the original coordinate space without
+        # needing rescale.
+        image = _jpeg_bytes(size=(1200, 1600))
+        bbox_json = json.dumps({"x": 100, "y": 200, "w": 800, "h": 1100})
+        client = _mock_client(_response_with_text(bbox_json))
+
+        result = haiku_bbox_crop(image, client=client)
+
+        assert result is not None
+        with Image.open(io.BytesIO(result)) as out:
+            # PIL's .crop truncates; the output should be close to 800x1100.
+            assert abs(out.size[0] - 800) <= 2
+            assert abs(out.size[1] - 1100) <= 2
+
+    def test_bad_json_returns_none(self):
+        image = _jpeg_bytes()
+        client = _mock_client(_response_with_text("sorry I can't help with that"))
+
+        assert haiku_bbox_crop(image, client=client) is None
+
+    def test_haiku_explicit_no_card_returns_none(self):
+        image = _jpeg_bytes()
+        bbox_json = json.dumps({"x": 0, "y": 0, "w": 0, "h": 0})
+        client = _mock_client(_response_with_text(bbox_json))
+
+        assert haiku_bbox_crop(image, client=client) is None
+
+    def test_empty_response_returns_none(self):
+        image = _jpeg_bytes()
+        client = _mock_client(_empty_response())
+
+        assert haiku_bbox_crop(image, client=client) is None
+
+    def test_empty_image_bytes_returns_none(self):
+        client = _mock_client()
+        assert haiku_bbox_crop(b"", client=client) is None
+        client.messages.create.assert_not_called()
+
+    def test_haiku_api_exception_returns_none(self):
+        client = MagicMock()
+        client.messages.create.side_effect = RuntimeError("anthropic down")
+
+        image = _jpeg_bytes()
+        assert haiku_bbox_crop(image, client=client) is None
+
+    def test_passes_model_through(self):
+        image = _jpeg_bytes()
+        bbox_json = json.dumps({"x": 0, "y": 0, "w": 100, "h": 140})
+        client = _mock_client(_response_with_text(bbox_json))
+
+        haiku_bbox_crop(image, client=client, model="claude-test-model")
+
+        call = client.messages.create.call_args
+        assert call.kwargs["model"] == "claude-test-model"
+        assert call.kwargs["temperature"] == 0.0
+
+    def test_unreadable_image_returns_none(self):
+        client = _mock_client(_response_with_text(json.dumps({"x": 0, "y": 0, "w": 10, "h": 10})))
+        # _prepare_for_anthropic can handle garbage by returning it passthrough-ish,
+        # but Image.open later will fail. haiku_bbox should catch that.
+        assert haiku_bbox_crop(b"not an image at all", client=client) is None


### PR DESCRIPTION
## Summary

Completes the server-side crop cascade. When SAM fails to produce a usable crop, Haiku is asked for the bounding box and PIL crops to it. Cheap (~\$0.0005 per call), no new runtime deps.

**Final cascade order:**
1. `precropped` (client-supplied)
2. `pil_trim` (PIL threshold + trim)
3. `sam` (SAM ViT-B semantic seg)
4. **`haiku_bbox`** ← this PR
5. `passthrough`

All stages flow through the same three-gate wrapper: geometric validator + text-count regression guard + (classify-error guard removed previously).

## Details

- `app/cropper/haiku_bbox.py` (~200 lines): prompts Haiku for `{"x","y","w","h"}` at temperature=0. Parses JSON (handles code fences), rejects zero/negative dims, rescales bounding box from the `_prepare_for_anthropic` downscaled coordinate system back to the original dimensions so the crop preserves full resolution. Every failure path returns None → cascade advances.
- Registered in `_STRATEGIES` as `("haiku_bbox", haiku_bbox, "haiku_bbox_crop")`. Late-binding via `getattr(module, attr)` keeps monkey-patching testable.

## Tests

- 17 new haiku_bbox unit tests (parse helpers + rescale + happy path + every failure mode)
- 4 cascade tests for haiku_bbox's cascade position (wins when earlier fail, None → passthrough, raises → passthrough, sam-raises → haiku_bbox)
- 126 unit tests total, 88.7% coverage

## Test plan

- [ ] `test` + `deploy-preview` + `preview-smoke` green.
- [ ] Merge → prod pipeline green.
- [ ] Manually test with an image where SAM is known to fail (cluttered background, rotated or occluded card) — should trigger `haiku_bbox` and return `cropped_source: "haiku_bbox"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)