### PR TITLE
feat(slice-3): unified gates + pil_trim_light

### DIFF
--- a/app/cropper/__init__.py
+++ b/app/cropper/__init__.py
@@ -4,11 +4,11 @@ Mirrors the cropAttempts waterfall from script-frontend's imageProcessor.js
 but restricted to strategies that run server-side (macOS Swift croppers stay
 client-side).
 
-Every cropping strategy flows through the SAME three-gate check, so adding
-a new cropper (MobileSAM, classical contour, haiku_bbox, ...) is just a
-matter of appending to `_STRATEGIES`. The gates are applied in the
-wrapper, not in each strategy, so a new cropper can't accidentally skip
-fallback logic.
+Every cropping strategy — including the client-supplied `precropped` —
+flows through the SAME two-gate check, so adding a new cropper (MobileSAM,
+classical contour, ...) is just a matter of appending to `_STRATEGIES`.
+The gates are applied in the wrapper, not in each strategy, so a new
+cropper can't accidentally skip fallback logic.
 
 Gates (applied to every strategy uniformly):
 
@@ -21,25 +21,18 @@ Gates (applied to every strategy uniformly):
    `MIN_CASCADE_TEXT_RATIO` of that baseline, or the stage is rejected.
    Catches wrong-region crops that *happen* to be card-shaped.
 
-   (An earlier iteration also had a "classify-error guard" — reject when
-   players+card_number both null AND side=back — but it misfired on
-   legitimate multi-player leaders/combo card backs where those fields
-   are genuinely null. The text-count gate alone is enough to catch
-   wrong-region crops without false-rejecting real backs.)
-
 If every strategy fails, the passthrough fallback carries whatever
-orient+classify produced on the raw image — which may itself return
-empty players / null card_number. That's acceptable: the client can
-surface it as "preprocess couldn't identify this card" and route to a
-manual path upstream.
+orient+classify produced on the raw image. The client can surface an
+empty-players / null-card_number response as "preprocess couldn't
+identify this card" and route to a manual path upstream.
 
 Source labels (order of preference):
-    precropped : client-supplied crop; trusted when validator + classify-
-                 error gates pass (no text-count gate since the baseline
-                 hasn't been computed yet on the happy path)
-    pil_trim   : PIL blur + threshold + trim + expand
-    sam        : SAM ViT-B semantic segmentation
-    passthrough: raw image forwarded unchanged
+    precropped      : client-supplied crop, or the raw upload as fallback
+    pil_trim_dark   : PIL blur + threshold + trim (card lighter than bg)
+    pil_trim_light  : PIL blur + threshold + trim (card darker than bg)
+    sam             : SAM ViT-B semantic segmentation
+    haiku_bbox      : Anthropic Haiku bounding-box crop
+    passthrough     : raw image forwarded unchanged
 """
 
 from __future__ import annotations
@@ -61,20 +54,20 @@ logger = logging.getLogger(__name__)
 # similar crops without letting a wrong-region crop slip through.
 MIN_CASCADE_TEXT_RATIO = 0.8
 
-
 # Type for a crop strategy: takes raw image bytes, returns cropped bytes or None.
 CropStrategy = Callable[[bytes], bytes | None]
 
 # Ordered list of server-side crop strategies. Each one flows through the
-# same three-gate wrapper (`_try_stage` below). Add new croppers here —
-# the gates are applied uniformly. `passthrough` is handled separately at
-# the end since it doesn't need gating (it's the always-available fallback).
+# same two-gate wrapper (`_try_stage` below). Stored as (name, module, attr)
+# so the callable is looked up fresh at each cascade invocation — tests
+# monkey-patch the module attribute and the cascade picks up the patch.
 #
-# Strategies are stored as (name, module, attr) so the callable is looked
-# up fresh at each cascade invocation — tests can monkeypatch the module
-# attribute and the cascade picks up the patch.
+# `precropped` is NOT in this list — it's handled as stage 1 inside `crop()`
+# because the candidate bytes come from a kwarg, not from applying a
+# function to `image_bytes`. Gate application is identical.
 _STRATEGIES: list[tuple[str, object, str]] = [
-    ("pil_trim", pil_trim, "trim"),
+    ("pil_trim_dark", pil_trim, "trim_dark"),
+    ("pil_trim_light", pil_trim, "trim_light"),
     ("sam", sam, "sam_crop"),
     ("haiku_bbox", haiku_bbox, "haiku_bbox_crop"),
 ]
@@ -84,10 +77,10 @@ _STRATEGIES: list[tuple[str, object, str]] = [
 class CropResult:
     """Outcome of the cascade.
 
-    Carries every downstream signal so main.py's /process handler becomes
-    a thin response-packaging layer. `returned_bytes_differ` is True when
-    the server produced new bytes the client doesn't already have — i.e.
-    the response should include `cropped_image_b64`.
+    `returned_bytes_differ` is True when the server produced new bytes the
+    client doesn't already have — i.e. the response should include
+    `cropped_image_b64`. False for precropped (client uploaded those exact
+    bytes) and passthrough (client uploaded the raw image).
     """
 
     image_bytes: bytes
@@ -97,24 +90,18 @@ class CropResult:
     classification: ClassifyResult
 
 
-def _orient_and_classify(image_bytes: bytes) -> tuple[OrientationResult, ClassifyResult]:
-    orient = detect_orientation(image_bytes)
-    rotated = rotate_image_bytes(image_bytes, orient.rotation_degrees)
-    classification = classify_card(rotated)
-    return orient, classification
-
-
 def _try_stage(
     *,
     source: str,
     candidate_bytes: bytes,
     source_area_bytes: bytes,
     text_threshold: int,
+    returned_bytes_differ: bool,
 ) -> CropResult | None:
-    """Apply the uniform three-gate check to a candidate crop.
+    """Apply the uniform two-gate check to a candidate crop.
 
     Returns a winning CropResult if all gates pass, None otherwise.
-    Caller can treat None as "advance to next strategy."
+    Caller can treat None as "advance to the next strategy."
     """
     check = is_plausible_crop(candidate_bytes, source_area_bytes=source_area_bytes)
     if not check.ok:
@@ -137,7 +124,7 @@ def _try_stage(
     return CropResult(
         image_bytes=candidate_bytes,
         source=source,
-        returned_bytes_differ=True,
+        returned_bytes_differ=returned_bytes_differ,
         orientation=orient,
         classification=classification,
     )
@@ -150,30 +137,16 @@ def crop(
 ) -> CropResult:
     """Run the crop cascade and return the winning result.
 
-    When `precropped_bytes` is provided, that's tried first. When absent,
-    the `image` upload is treated as the precropped candidate — preserves
-    backward compat with callers who do their own cropping.
-    """
-    # ── Stage 1 — precropped short-circuit ─────────────────────────────
-    # Client-supplied crop: trust it if validator passes AND classify
-    # doesn't hit the wrong-region signature. We skip the text-count gate
-    # here to avoid an extra baseline Vision call on the happy path; the
-    # classify-error check is much cheaper and catches most crop disasters.
-    candidate = precropped_bytes if precropped_bytes is not None else image_bytes
-    check = is_plausible_crop(candidate)
-    if check.ok:
-        orient, classification = _orient_and_classify(candidate)
-        return CropResult(
-            image_bytes=candidate,
-            source="precropped",
-            returned_bytes_differ=False,
-            orientation=orient,
-            classification=classification,
-        )
-    logger.info("cascade: precropped rejected by validator (%s)", check.reason)
+    When `precropped_bytes` is provided, that's tried first via `_try_stage`.
+    When absent, the `image` upload is used as the stage-1 candidate (slice-1
+    backward compat for callers who already cropped client-side).
 
-    # Baseline — used for both the text-count threshold and the passthrough
-    # fallback so we never orient the same bytes twice.
+    The baseline orient on `image_bytes` is computed up front — one extra
+    Vision call relative to the old precropped-short-circuit path — so the
+    text-count gate applies uniformly to every stage, including precropped.
+    """
+    # ── Baseline — used for the text-count threshold AND as the passthrough
+    # fallback orient. Computed once, reused throughout.
     baseline_orient = detect_orientation(image_bytes)
     text_threshold = max(1, int(baseline_orient.text_count * MIN_CASCADE_TEXT_RATIO))
     logger.info(
@@ -182,7 +155,21 @@ def crop(
         text_threshold,
     )
 
-    # ── Stages 2..N — server-side croppers through the uniform gate ───
+    # ── Stage 1 — precropped (or raw image as candidate) through the uniform gate.
+    # The client uploaded these exact bytes either way, so returned_bytes_differ
+    # stays False regardless of which branch wins.
+    stage1_candidate = precropped_bytes if precropped_bytes is not None else image_bytes
+    result = _try_stage(
+        source="precropped",
+        candidate_bytes=stage1_candidate,
+        source_area_bytes=image_bytes,
+        text_threshold=text_threshold,
+        returned_bytes_differ=False,
+    )
+    if result is not None:
+        return result
+
+    # ── Stages 2..N — server-side croppers through the same uniform gate.
     for source, module, fn_name in _STRATEGIES:
         strategy_fn: CropStrategy = getattr(module, fn_name)
         try:
@@ -198,13 +185,14 @@ def crop(
             candidate_bytes=produced,
             source_area_bytes=image_bytes,
             text_threshold=text_threshold,
+            returned_bytes_differ=True,
         )
         if result is not None:
             return result
 
     # ── Passthrough ─────────────────────────────────────────────────────
     # Unconditional fallback. Carries whatever orient+classify produced on
-    # the raw image; may itself be a classify-error response, which is the
+    # the raw image. May itself be empty-players / null card_number — the
     # honest "preprocess couldn't identify this card" signal.
     logger.info("cascade: falling through to passthrough")
     rotated = rotate_image_bytes(image_bytes, baseline_orient.rotation_degrees)

--- a/app/cropper/pil_trim.py
+++ b/app/cropper/pil_trim.py
@@ -1,40 +1,54 @@
-"""PIL-based trim — port of script-frontend's sharp.trim strategy.
+"""PIL-based trim — port of script-frontend's sharp.trim / magick.fuzz.trim.
 
-Works well on photos of cards on a near-solid (usually black or dark)
-background: blur to smooth noise, threshold out dark pixels, take the
-bounding box of the remaining content, then add a small border back so the
-next stages (orient, classify) don't clip the card edge.
+Works on clean-background photos of a single card: blur to smooth JPEG
+artifacts, threshold to separate card from background, take the bounding
+box, add a small border so downstream orient/classify don't clip the card
+edge.
 
-This replaces both `sharp.trim` and `magick.fuzz.trim` from the original
-cascade — they solve the same problem (background bleed around the card)
-at different thresholds, and PIL + ImageChops is close enough to either
-that running both is redundant.
+Two public entrypoints — same pipeline, opposite threshold directions:
+
+    trim_dark  — card is LIGHTER than the background
+                 (black scanner bed, dark desk). Foreground = pixels above
+                 `DARK_THRESHOLD`.
+
+    trim_light — card is DARKER than the background
+                 (white paper, light desk). Foreground = pixels below
+                 `LIGHT_THRESHOLD`.
+
+Both are registered as separate strategies in the cascade so each goes
+through the validator + text-count gate independently. Most clean-card
+photos are one or the other; the cascade just runs whichever wins.
 """
 
 from __future__ import annotations
 
 from io import BytesIO
+from typing import Literal
 
 from PIL import Image, ImageFilter
 
-# Downscale very large images before processing — libvips segfaults on 50MP+
-# inputs (per the script-frontend comment) and PIL is slow too. 3000px longest
-# edge is enough resolution to find card edges reliably.
+# Downscale very large images before processing — libvips / PIL are slow on
+# 50MP+ inputs. 3000px longest edge is enough to find card edges reliably.
 MAX_LONGEST_EDGE_PX = 3000
 
 # Gaussian blur radius before thresholding. Smooths JPEG artifacts + film
 # grain without dissolving real card edges.
 BLUR_RADIUS = 0.8
 
-# Threshold for "is this pixel background?" — values at or below this on the
-# grayscale channel are treated as background. 180 matches sharp.trim's
-# threshold (sharp uses a 0..255 scale with 180 meaning "trim anything
-# darker than this").
+# Threshold for "is this pixel background?" on the grayscale channel.
+# 180 matches script-frontend's sharp.trim (dark backgrounds).
 DARK_THRESHOLD = 180
+# Chosen empirically: backgrounds brighter than ~240 (paper white) reliably
+# sit above this, while card content typically has some sub-75 pixels
+# (shadows, dark text, borders). If cards start slipping through on mid-
+# tone light backgrounds, bump upward.
+LIGHT_THRESHOLD = 75
 
-# Border added back around the bounding box so the orient + classify stages
-# have breathing room. In pixels.
+# Border added back around the bounding box so orient + classify have
+# breathing room. In pixels.
 BORDER_PX = 10
+
+Direction = Literal["above", "below"]
 
 
 def _maybe_downscale(img: Image.Image) -> Image.Image:
@@ -46,12 +60,19 @@ def _maybe_downscale(img: Image.Image) -> Image.Image:
     return img.resize(new_size, Image.Resampling.LANCZOS)
 
 
-def trim(image_bytes: bytes) -> bytes | None:
-    """Run PIL-based background trim on the image.
+def _trim_with_threshold(
+    image_bytes: bytes,
+    *,
+    threshold: int,
+    direction: Direction,
+) -> bytes | None:
+    """Shared trim pipeline parameterized by threshold direction.
 
-    Returns the trimmed JPEG bytes, or None if no meaningful bounding box
-    could be found (e.g. the whole image is below the dark threshold, or
-    the input is unreadable).
+    direction="above": foreground = pixels brighter than threshold (dark background).
+    direction="below": foreground = pixels darker than threshold (light background).
+
+    Returns trimmed JPEG bytes, or None if no meaningful bounding box was
+    found (unreadable input, or every pixel is on one side of the threshold).
     """
     try:
         img = Image.open(BytesIO(image_bytes))
@@ -65,10 +86,13 @@ def trim(image_bytes: bytes) -> bytes | None:
     blurred = img.filter(ImageFilter.GaussianBlur(radius=BLUR_RADIUS))
     gray = blurred.convert("L")
 
-    # Create a "foreground" mask: pixels brighter than the dark threshold are
-    # content; everything else is background. getbbox() returns the bounding
-    # box of non-black pixels, so we threshold into a binary image first.
-    mask = gray.point(lambda p: 255 if p > DARK_THRESHOLD else 0, mode="L")
+    # Binary mask where foreground pixels are 255 and background is 0;
+    # getbbox() then returns the bounding box of foreground.
+    if direction == "above":
+        mask = gray.point(lambda p: 255 if p > threshold else 0, mode="L")
+    else:  # "below"
+        mask = gray.point(lambda p: 255 if p < threshold else 0, mode="L")
+
     bbox = mask.getbbox()
     if bbox is None:
         return None
@@ -79,9 +103,9 @@ def trim(image_bytes: bytes) -> bytes | None:
 
     cropped = img.crop(bbox)
 
-    # Add a black border so the cropper doesn't shave off a pixel-thin slice
-    # of the card edge. `ImageChops.offset` + expand would also work; this is
-    # clearer.
+    # Add a black border so downstream cropping doesn't shave off a pixel-
+    # thin slice of the card edge. Border color is cosmetic — it's padding
+    # around the card, not a background match.
     w, h = cropped.size
     bordered = Image.new("RGB", (w + 2 * BORDER_PX, h + 2 * BORDER_PX), color="black")
     bordered.paste(cropped, (BORDER_PX, BORDER_PX))
@@ -89,3 +113,13 @@ def trim(image_bytes: bytes) -> bytes | None:
     out = BytesIO()
     bordered.save(out, format="JPEG", quality=90)
     return out.getvalue()
+
+
+def trim_dark(image_bytes: bytes) -> bytes | None:
+    """Trim for a light card on a dark background (black scanner bed, dark desk)."""
+    return _trim_with_threshold(image_bytes, threshold=DARK_THRESHOLD, direction="above")
+
+
+def trim_light(image_bytes: bytes) -> bytes | None:
+    """Trim for a dark card on a light background (white paper, light desk)."""
+    return _trim_with_threshold(image_bytes, threshold=LIGHT_THRESHOLD, direction="below")

--- a/tests/integration/test_fixtures_e2e.py
+++ b/tests/integration/test_fixtures_e2e.py
@@ -81,7 +81,8 @@ def test_fixture_end_to_end(case: FixtureCase):
     # known label and the b64 field is consistent with it.
     assert body["cropped_source"] in {
         "precropped",
-        "pil_trim",
+        "pil_trim_dark",
+        "pil_trim_light",
         "sam",
         "passthrough",
     }, f"{case.name}: unexpected cropped_source {body['cropped_source']!r}"

--- a/tests/smoke/test_deployed.py
+++ b/tests/smoke/test_deployed.py
@@ -141,7 +141,8 @@ class TestProcessHappyPath:
         # precropped validator. cropped_image_b64 should be null in that case.
         assert body["cropped_source"] in {
             "precropped",
-            "pil_trim",
+            "pil_trim_dark",
+            "pil_trim_light",
             "passthrough",
         }, f"unexpected cropped_source {body['cropped_source']!r}"
         if body["cropped_source"] == "precropped":

--- a/tests/unit/test_cropper_cascade.py
+++ b/tests/unit/test_cropper_cascade.py
@@ -1,13 +1,13 @@
 """Unit tests for app.cropper.crop — the cascade orchestrator.
 
-Stubs the four building blocks the cascade talks to:
-    pil_trim.trim, sam.sam_crop      — crop strategies
-    detect_orientation, classify_card — quality gate inputs
+Slice 3 folded precropped into the same uniform-gate loop as every other
+strategy. Every stage now:
+  1. Validator (is_plausible_crop)
+  2. Text-count regression guard (against baseline orient on raw image)
+  3. Classify call (no classify-level gate — result is packaged as-is)
 
-Each test exercises one branch of the three-gate wrapper:
-    1. geometric validator
-    2. text-count regression guard (vs. passthrough baseline)
-    3. classify-error guard (player+card_number null + side=back)
+Tests stub `detect_orientation` and `classify_card` on the `cropper`
+module binding because that's where `crop()` imports them.
 """
 
 from __future__ import annotations
@@ -65,14 +65,9 @@ def _classify(
     )
 
 
-def _classify_error() -> ClassifyResult:
-    """The null/null/back pattern the cascade treats as a crop error."""
-    return _classify(player=None, card_number=None, side="back")
-
-
 @pytest.fixture
 def stub_orient(monkeypatch):
-    """Factory: install an orient stub that returns the same result for every call."""
+    """Install an orient stub that returns the same result for every call."""
 
     def _install(result: OrientationResult | None = None) -> list[bytes]:
         result = result or _orient()
@@ -124,10 +119,37 @@ def stub_classify(monkeypatch):
     return _install
 
 
-class TestPrecroppedShortCircuit:
-    def test_valid_precropped_with_good_classify_is_used(self, stub_orient, stub_classify):
+@pytest.fixture
+def disable_server_strategies(monkeypatch):
+    """Factory to stub out the server-side croppers so only precropped runs.
+
+    Returns a helper that accepts kwargs for each strategy (default None).
+    Any not explicitly overridden returns None (skipped by cascade).
+    """
+
+    def _install(**overrides) -> None:
+        defaults = {
+            "trim_dark": None,
+            "trim_light": None,
+            "sam_crop": None,
+            "haiku_bbox_crop": None,
+        }
+        defaults.update(overrides)
+        monkeypatch.setattr("app.cropper.pil_trim.trim_dark", lambda _b: defaults["trim_dark"])
+        monkeypatch.setattr("app.cropper.pil_trim.trim_light", lambda _b: defaults["trim_light"])
+        monkeypatch.setattr("app.cropper.sam.sam_crop", lambda _b: defaults["sam_crop"])
+        monkeypatch.setattr(
+            "app.cropper.haiku_bbox.haiku_bbox_crop", lambda _b: defaults["haiku_bbox_crop"]
+        )
+
+    return _install
+
+
+class TestPrecroppedStage:
+    def test_valid_precropped_wins(self, stub_orient, stub_classify, disable_server_strategies):
         stub_orient()
         stub_classify(_classify())
+        disable_server_strategies()
 
         image = _card_jpeg(size=(1200, 1600))
         precropped = _card_jpeg(size=(500, 700))
@@ -137,12 +159,14 @@ class TestPrecroppedShortCircuit:
         assert result.source == "precropped"
         assert result.image_bytes == precropped
         assert result.returned_bytes_differ is False
-        assert result.classification.player == "Ichiro"
+        assert result.classification.players == ["Ichiro"]
 
-    def test_missing_precropped_uses_image_when_image_validates(self, stub_orient, stub_classify):
-        # Slice-1 compat: no precropped, image looks card-shaped → short-circuit.
+    def test_missing_precropped_uses_image_candidate(
+        self, stub_orient, stub_classify, disable_server_strategies
+    ):
         stub_orient()
         stub_classify(_classify())
+        disable_server_strategies()
 
         image = _card_jpeg(size=(500, 700))
 
@@ -150,46 +174,97 @@ class TestPrecroppedShortCircuit:
 
         assert result.source == "precropped"
         assert result.image_bytes == image
+        assert result.returned_bytes_differ is False
 
-    def test_precropped_classify_error_is_kept_not_dropped(
-        self, monkeypatch, stub_orient, stub_classify
+    def test_precropped_fails_validator_falls_through(
+        self, stub_orient, stub_classify, disable_server_strategies
     ):
-        # The empty-players/null-card_number/back pattern is legitimate on
-        # multi-player leaders/combo card backs. When precropped passes the
-        # validator we trust classify's output — even if it's "hard to
-        # identify" — rather than falling through. The cascade's text-count
-        # gate is enough to catch wrong-region crops without this heuristic.
+        # Tiny precropped fails the min-side check → falls through to server stages.
+        good_trim = _card_jpeg(size=(500, 700))
         stub_orient()
-        stub_classify(_classify_error())
-        # Cascade should short-circuit on precropped with this classify
-        # output, NOT call pil_trim. Guard: if pil_trim is invoked, the
-        # test fails because stub_classify exhausted its queue but the
-        # assertion below doesn't care about fall-through behavior.
-        monkeypatch.setattr(
-            "app.cropper.pil_trim.trim",
-            lambda _b: pytest.fail("cascade should not have reached pil_trim"),
-        )
+        stub_classify(_classify())
+        disable_server_strategies(trim_dark=good_trim)
 
         image = _card_jpeg(size=(1200, 1600))
-        precropped = _card_jpeg(size=(500, 700))
+        bad_precropped = _tiny_jpeg()
+
+        result = crop(image_bytes=image, precropped_bytes=bad_precropped)
+
+        assert result.source == "pil_trim_dark"
+        assert result.image_bytes == good_trim
+        assert result.returned_bytes_differ is True
+
+    def test_precropped_fails_text_count_gate_falls_through(
+        self, stub_orient_by_call, stub_classify, disable_server_strategies
+    ):
+        """Precropped passes validator but has text_count below threshold."""
+        good_trim = _card_jpeg(size=(500, 700))
+        disable_server_strategies(trim_dark=good_trim)
+
+        # Baseline text=10 → threshold=8. Precropped returns text=5 (fails gate).
+        # pil_trim_dark then returns text=10 (wins).
+        stub_orient_by_call(
+            _orient(text_count=10),  # baseline (raw image)
+            _orient(text_count=5),  # precropped — fails gate
+            _orient(text_count=10),  # pil_trim_dark output
+        )
+        stub_classify(_classify())  # pil_trim_dark's classify
+
+        image = _card_jpeg(size=(1200, 1600))
+        precropped = _card_jpeg(size=(500, 700))  # passes validator but low text
 
         result = crop(image_bytes=image, precropped_bytes=precropped)
 
-        assert result.source == "precropped"
-        assert result.classification.players == []
-        assert result.classification.side == "back"
+        assert result.source == "pil_trim_dark"
 
 
-class TestPilTrimStage:
-    def test_valid_pil_trim_with_sufficient_text_wins(
-        self, monkeypatch, stub_orient, stub_classify
+class TestPilTrimStages:
+    def test_pil_trim_dark_wins_when_it_produces_good_output(
+        self, stub_orient, stub_classify, disable_server_strategies
     ):
         good = _card_jpeg(size=(500, 700))
-        monkeypatch.setattr("app.cropper.pil_trim.trim", lambda _b: good)
-
-        # Every orient call returns text_count=10. Threshold = 0.8 * 10 = 8,
-        # so pil_trim's 10 clears the gate.
         stub_orient()
+        stub_classify(_classify())
+        disable_server_strategies(trim_dark=good)
+
+        image = _card_jpeg(size=(1200, 1600))
+        bad_precropped = _tiny_jpeg()
+
+        result = crop(image_bytes=image, precropped_bytes=bad_precropped)
+
+        assert result.source == "pil_trim_dark"
+        assert result.returned_bytes_differ is True
+
+    def test_pil_trim_light_wins_when_dark_returns_none(
+        self, stub_orient, stub_classify, disable_server_strategies
+    ):
+        good = _card_jpeg(size=(500, 700))
+        stub_orient()
+        stub_classify(_classify())
+        disable_server_strategies(trim_dark=None, trim_light=good)
+
+        image = _card_jpeg(size=(1200, 1600))
+        bad_precropped = _tiny_jpeg()
+
+        result = crop(image_bytes=image, precropped_bytes=bad_precropped)
+
+        assert result.source == "pil_trim_light"
+        assert result.returned_bytes_differ is True
+
+    def test_pil_trim_text_count_drop_falls_through_to_sam(
+        self, stub_orient_by_call, stub_classify, disable_server_strategies
+    ):
+        """pil_trim_dark passes validator but drops too much text → SAM runs."""
+        good = _card_jpeg(size=(500, 700))
+        disable_server_strategies(trim_dark=good, sam_crop=good)
+
+        # baseline=10 → threshold=8. precropped (100x140) fails validator so
+        # no orient. pil_trim_dark output text=5 (fails gate). SAM output text=10 (wins).
+        stub_orient_by_call(
+            _orient(text_count=10),  # baseline
+            _orient(text_count=5),  # pil_trim_dark output
+            _orient(text_count=10),  # sam output
+        )
         stub_classify(_classify())
 
         image = _card_jpeg(size=(1200, 1600))
@@ -197,62 +272,17 @@ class TestPilTrimStage:
 
         result = crop(image_bytes=image, precropped_bytes=bad_precropped)
 
-        assert result.source == "pil_trim"
-
-    def test_pil_trim_text_count_drop_falls_through(
-        self, monkeypatch, stub_orient_by_call, stub_classify
-    ):
-        """pil_trim passes validator but drops too much text → fall through."""
-        good_sam = _card_jpeg(size=(500, 700))
-        monkeypatch.setattr("app.cropper.pil_trim.trim", lambda _b: good_sam)
-        monkeypatch.setattr("app.cropper.sam.sam_crop", lambda _b: good_sam)
-
-        # Baseline text=10 → threshold=8. pil_trim's text=5 fails the gate.
-        # Then cascade tries SAM (stubbed with text=10) → wins.
-        stub_orient_by_call(
-            _orient(text_count=10),  # baseline (passthrough)
-            _orient(text_count=5),  # pil_trim output
-            _orient(text_count=10),  # sam output
-        )
-        stub_classify(_classify())  # sam's classify (pil_trim never reached classify)
-
-        image = _card_jpeg(size=(1200, 1600))
-        bad_precropped = _tiny_jpeg()
-
-        result = crop(image_bytes=image, precropped_bytes=bad_precropped)
-
         assert result.source == "sam"
-
-    def test_pil_trim_classify_error_is_kept(self, monkeypatch, stub_orient, stub_classify):
-        """Empty players + back is legitimate on multi-player backs — don't fall through."""
-        good = _card_jpeg(size=(500, 700))
-        monkeypatch.setattr("app.cropper.pil_trim.trim", lambda _b: good)
-        # If cascade falls through to SAM, the test fails loudly.
-        monkeypatch.setattr(
-            "app.cropper.sam.sam_crop",
-            lambda _b: pytest.fail("cascade should not have reached SAM"),
-        )
-
-        stub_orient()
-        stub_classify(_classify_error())
-
-        image = _card_jpeg(size=(1200, 1600))
-        bad_precropped = _tiny_jpeg()
-
-        result = crop(image_bytes=image, precropped_bytes=bad_precropped)
-
-        assert result.source == "pil_trim"
-        assert result.classification.players == []
 
 
 class TestSamStage:
-    def test_valid_sam_wins_when_pil_trim_empty(self, monkeypatch, stub_orient, stub_classify):
+    def test_valid_sam_wins_when_trim_variants_empty(
+        self, stub_orient, stub_classify, disable_server_strategies
+    ):
         good = _card_jpeg(size=(500, 700))
-        monkeypatch.setattr("app.cropper.pil_trim.trim", lambda _b: None)
-        monkeypatch.setattr("app.cropper.sam.sam_crop", lambda _b: good)
-
         stub_orient()
         stub_classify(_classify())
+        disable_server_strategies(sam_crop=good)
 
         image = _card_jpeg(size=(1200, 1600))
         bad_precropped = _tiny_jpeg()
@@ -261,27 +291,10 @@ class TestSamStage:
 
         assert result.source == "sam"
 
-    def test_sam_classify_error_is_kept(self, monkeypatch, stub_orient, stub_classify):
-        """Same rule as pil_trim: empty players on SAM's output is legitimate."""
+    def test_sam_raises_falls_through_to_haiku_bbox(self, stub_orient, stub_classify, monkeypatch):
         good = _card_jpeg(size=(500, 700))
-        monkeypatch.setattr("app.cropper.pil_trim.trim", lambda _b: None)
-        monkeypatch.setattr("app.cropper.sam.sam_crop", lambda _b: good)
-
-        stub_orient()
-        stub_classify(_classify_error())
-
-        image = _card_jpeg(size=(1200, 1600))
-        bad_precropped = _tiny_jpeg()
-
-        result = crop(image_bytes=image, precropped_bytes=bad_precropped)
-
-        assert result.source == "sam"
-        assert result.classification.players == []
-
-    def test_sam_raises_falls_through_to_haiku_bbox(self, monkeypatch, stub_orient, stub_classify):
-        """pil_trim empty + SAM raises → cascade tries haiku_bbox next."""
-        good = _card_jpeg(size=(500, 700))
-        monkeypatch.setattr("app.cropper.pil_trim.trim", lambda _b: None)
+        monkeypatch.setattr("app.cropper.pil_trim.trim_dark", lambda _b: None)
+        monkeypatch.setattr("app.cropper.pil_trim.trim_light", lambda _b: None)
 
         def _boom(_b):
             raise RuntimeError("SAM crashed")
@@ -301,16 +314,13 @@ class TestSamStage:
 
 
 class TestHaikuBboxStage:
-    def test_haiku_bbox_wins_when_earlier_stages_fail(
-        self, monkeypatch, stub_orient, stub_classify
+    def test_haiku_bbox_wins_when_earlier_fail(
+        self, stub_orient, stub_classify, disable_server_strategies
     ):
         good = _card_jpeg(size=(500, 700))
-        monkeypatch.setattr("app.cropper.pil_trim.trim", lambda _b: None)
-        monkeypatch.setattr("app.cropper.sam.sam_crop", lambda _b: None)
-        monkeypatch.setattr("app.cropper.haiku_bbox.haiku_bbox_crop", lambda _b: good)
-
         stub_orient()
         stub_classify(_classify())
+        disable_server_strategies(haiku_bbox_crop=good)
 
         image = _card_jpeg(size=(1200, 1600))
         bad_precropped = _tiny_jpeg()
@@ -320,27 +330,11 @@ class TestHaikuBboxStage:
         assert result.source == "haiku_bbox"
         assert result.returned_bytes_differ is True
 
-    def test_haiku_bbox_empty_falls_through_to_passthrough(
-        self, monkeypatch, stub_orient, stub_classify
-    ):
-        monkeypatch.setattr("app.cropper.pil_trim.trim", lambda _b: None)
-        monkeypatch.setattr("app.cropper.sam.sam_crop", lambda _b: None)
-        monkeypatch.setattr("app.cropper.haiku_bbox.haiku_bbox_crop", lambda _b: None)
-
-        stub_orient()
-        stub_classify(_classify())
-
-        image = _card_jpeg(size=(1200, 1600))
-        bad_precropped = _tiny_jpeg()
-
-        result = crop(image_bytes=image, precropped_bytes=bad_precropped)
-
-        assert result.source == "passthrough"
-
     def test_haiku_bbox_raises_falls_through_to_passthrough(
-        self, monkeypatch, stub_orient, stub_classify
+        self, stub_orient, stub_classify, monkeypatch
     ):
-        monkeypatch.setattr("app.cropper.pil_trim.trim", lambda _b: None)
+        monkeypatch.setattr("app.cropper.pil_trim.trim_dark", lambda _b: None)
+        monkeypatch.setattr("app.cropper.pil_trim.trim_light", lambda _b: None)
         monkeypatch.setattr("app.cropper.sam.sam_crop", lambda _b: None)
 
         def _boom(_b):
@@ -360,16 +354,12 @@ class TestHaikuBboxStage:
 
 
 class TestPassthroughFallback:
-    def test_all_stages_fail_returns_passthrough_with_its_own_classify(
-        self, monkeypatch, stub_orient, stub_classify
+    def test_all_stages_fail_returns_passthrough(
+        self, stub_orient, stub_classify, disable_server_strategies
     ):
-        """Every stage rejects → passthrough's classify rides through (even if an error)."""
-        monkeypatch.setattr("app.cropper.pil_trim.trim", lambda _b: None)
-        monkeypatch.setattr("app.cropper.sam.sam_crop", lambda _b: None)
-
         stub_orient()
-        stub_classify(_classify_error())
-        # Only one classify call: on the passthrough's rotated bytes.
+        stub_classify(_classify())
+        disable_server_strategies()  # all None
 
         image = _card_jpeg(size=(1200, 1600))
         bad_precropped = _tiny_jpeg()
@@ -377,43 +367,45 @@ class TestPassthroughFallback:
         result = crop(image_bytes=image, precropped_bytes=bad_precropped)
 
         assert result.source == "passthrough"
-        assert result.classification.player is None
+        assert result.image_bytes == image
+        assert result.returned_bytes_differ is False
+
+    def test_passthrough_carries_empty_players_when_unidentifiable(
+        self, stub_orient, stub_classify, disable_server_strategies
+    ):
+        """All stages fail + classify returns empty fields → passthrough is honest."""
+        stub_orient()
+        stub_classify(_classify(player=None, team=None, card_number=None, side="back"))
+        disable_server_strategies()
+
+        image = _card_jpeg(size=(1200, 1600))
+        bad_precropped = _tiny_jpeg()
+
+        result = crop(image_bytes=image, precropped_bytes=bad_precropped)
+
+        assert result.source == "passthrough"
+        assert result.classification.players == []
         assert result.classification.card_number is None
         assert result.classification.side == "back"
 
-    def test_sam_output_rejected_by_validator_passthrough_wins(
-        self, monkeypatch, stub_orient, stub_classify
-    ):
-        """SAM returns bytes that fail the validator (too small) → fall through."""
-        monkeypatch.setattr("app.cropper.pil_trim.trim", lambda _b: None)
-        monkeypatch.setattr("app.cropper.sam.sam_crop", lambda _b: _tiny_jpeg())
-
-        stub_orient()
-        stub_classify(_classify())
-
-        image = _card_jpeg(size=(1200, 1600))
-        bad_precropped = _tiny_jpeg()
-
-        result = crop(image_bytes=image, precropped_bytes=bad_precropped)
-
-        assert result.source == "passthrough"
-
 
 class TestCropResultShape:
-    def test_is_immutable_dataclass(self, stub_orient, stub_classify):
+    def test_is_immutable_dataclass(self, stub_orient, stub_classify, disable_server_strategies):
         stub_orient()
         stub_classify(_classify())
+        disable_server_strategies()
         result = crop(image_bytes=_card_jpeg(), precropped_bytes=None)
-        # Frozen dataclass raises FrozenInstanceError (subclass of AttributeError)
-        # on any field mutation.
         with pytest.raises(AttributeError):
             result.source = "other"  # type: ignore[misc]
 
-    def test_carries_orientation_and_classification(self, stub_orient, stub_classify):
+    def test_carries_orientation_and_classification(
+        self, stub_orient, stub_classify, disable_server_strategies
+    ):
         stub_orient(_orient(text_count=42, rotation=90, confidence=0.77))
         stub_classify(_classify(player="Jeter", team="Yankees", card_number="2"))
+        disable_server_strategies()
         result: CropResult = crop(image_bytes=_card_jpeg(), precropped_bytes=None)
         assert result.orientation.text_count == 42
         assert result.orientation.rotation_degrees == 90
-        assert result.classification.player == "Jeter"
+        assert result.classification.players == ["Jeter"]
         assert result.classification.card_number == "2"

--- a/tests/unit/test_cropper_pil_trim.py
+++ b/tests/unit/test_cropper_pil_trim.py
@@ -1,74 +1,116 @@
 """Unit tests for app.cropper.pil_trim.
 
-Focuses on the observable behavior: given a card-on-dark-background input,
-the trim extracts the card region and returns JPEG bytes with reasonable
-dimensions. Precise pixel-exact matching against a reference image is
-brittle, so we assert shape properties instead.
+Two public entrypoints — `trim_dark` for light-on-dark, `trim_light` for
+dark-on-light — share the same blur/threshold/bbox/border pipeline and are
+exercised through parameterized tests. We assert shape properties rather
+than pixel-exact output so Gaussian blur jitter + JPEG quantization don't
+make tests flaky.
 """
 
 from __future__ import annotations
 
 import io
 
+import pytest
 from PIL import Image, ImageDraw
 
-from app.cropper.pil_trim import BORDER_PX, MAX_LONGEST_EDGE_PX, trim
+from app.cropper.pil_trim import (
+    BORDER_PX,
+    MAX_LONGEST_EDGE_PX,
+    trim_dark,
+    trim_light,
+)
 
 
-def _card_on_dark_background(
+def _card_on_background(
     *,
+    card_color: str,
+    bg_color: str,
     canvas_size: tuple[int, int] = (1200, 1600),
     card_box: tuple[int, int, int, int] = (200, 300, 1000, 1400),
-    card_color: str = "white",
 ) -> bytes:
-    """Render a light card on a black canvas.
-
-    Returns JPEG bytes the trim can meaningfully cut.
-    """
-    img = Image.new("RGB", canvas_size, color="black")
-    draw = ImageDraw.Draw(img)
-    draw.rectangle(card_box, fill=card_color)
+    """Render a single rectangle (card) on a solid-color canvas (background)."""
+    img = Image.new("RGB", canvas_size, color=bg_color)
+    ImageDraw.Draw(img).rectangle(card_box, fill=card_color)
     out = io.BytesIO()
     img.save(out, format="JPEG", quality=90)
     return out.getvalue()
 
 
-class TestTrim:
-    def test_returns_bytes_for_card_on_background(self):
-        result = trim(_card_on_dark_background())
+# Each fixture: (trim_fn, card_color, bg_color). Both pipelines see the same
+# 800×1100 card with a 10px border added back after the crop.
+_VARIANTS = [
+    pytest.param(trim_dark, "white", "black", id="dark_bg_light_card"),
+    pytest.param(trim_light, "black", "white", id="light_bg_dark_card"),
+]
+
+
+class TestTrimHappyPath:
+    @pytest.mark.parametrize("trim_fn,card_color,bg_color", _VARIANTS)
+    def test_returns_bytes_for_card_on_background(self, trim_fn, card_color, bg_color):
+        result = trim_fn(_card_on_background(card_color=card_color, bg_color=bg_color))
         assert result is not None
-        # Round-trip through PIL to confirm it decoded as an image.
         with Image.open(io.BytesIO(result)) as out:
             assert out.size[0] > 0 and out.size[1] > 0
 
-    def test_output_includes_border(self):
-        # Card is 800 wide × 1100 tall; output should be roughly that plus
-        # 2*BORDER_PX on each axis.
-        result = trim(_card_on_dark_background())
+    @pytest.mark.parametrize("trim_fn,card_color,bg_color", _VARIANTS)
+    def test_output_includes_border(self, trim_fn, card_color, bg_color):
+        result = trim_fn(_card_on_background(card_color=card_color, bg_color=bg_color))
         assert result is not None
         with Image.open(io.BytesIO(result)) as out:
             w, h = out.size
+            # Card is 800×1100; output dimensions should be the card size plus
+            # up to 2*BORDER_PX on each axis. A small Gaussian-blur fringe is
+            # expected, so we allow a 10px slack.
             assert 800 <= w <= 800 + 2 * BORDER_PX + 10
             assert 1100 <= h <= 1100 + 2 * BORDER_PX + 10
 
-    def test_downscales_very_large_inputs(self):
-        # Construct an image well over the downscale threshold; verify the
-        # output doesn't exceed the cap on either dimension.
-        big = _card_on_dark_background(
+    @pytest.mark.parametrize("trim_fn,card_color,bg_color", _VARIANTS)
+    def test_downscales_very_large_inputs(self, trim_fn, card_color, bg_color):
+        big = _card_on_background(
+            card_color=card_color,
+            bg_color=bg_color,
             canvas_size=(5000, 6000),
             card_box=(800, 1000, 4200, 5000),
         )
-        result = trim(big)
+        result = trim_fn(big)
         assert result is not None
         with Image.open(io.BytesIO(result)) as out:
             assert max(out.size) <= MAX_LONGEST_EDGE_PX
 
-    def test_returns_none_for_all_black_image(self):
+
+class TestTrimDarkRejects:
+    def test_all_black_image_returns_none(self):
+        """Every pixel below the dark threshold → getbbox returns None."""
         img = Image.new("RGB", (1000, 1400), color="black")
         buf = io.BytesIO()
         img.save(buf, format="JPEG", quality=90)
-        # Nothing above the threshold → getbbox returns None.
-        assert trim(buf.getvalue()) is None
+        assert trim_dark(buf.getvalue()) is None
 
-    def test_returns_none_for_unreadable_bytes(self):
-        assert trim(b"definitely not an image") is None
+    def test_unreadable_bytes_returns_none(self):
+        assert trim_dark(b"definitely not an image") is None
+
+    def test_wrong_polarity_card_returns_none(self):
+        """Dark card on light bg → trim_dark finds no bright pixels."""
+        img = _card_on_background(card_color="black", bg_color="white")
+        # trim_dark expects bright foreground; everywhere above threshold
+        # is the background itself, so the bbox would be the entire image
+        # → no useful trim. Not asserting None here because getbbox can
+        # return the full canvas; we just confirm it doesn't crash.
+        result = trim_dark(img)
+        if result is not None:
+            with Image.open(io.BytesIO(result)) as out:
+                # Output should be ~ the full canvas (no meaningful trim).
+                assert out.size[0] >= 1000
+
+
+class TestTrimLightRejects:
+    def test_all_white_image_returns_none(self):
+        """Every pixel above the light threshold → getbbox returns None."""
+        img = Image.new("RGB", (1000, 1400), color="white")
+        buf = io.BytesIO()
+        img.save(buf, format="JPEG", quality=90)
+        assert trim_light(buf.getvalue()) is None
+
+    def test_unreadable_bytes_returns_none(self):
+        assert trim_light(b"definitely not an image") is None

--- a/tests/unit/test_process_route.py
+++ b/tests/unit/test_process_route.py
@@ -370,7 +370,7 @@ class TestPrecroppedField:
         # Force pil_trim to return known good card-shaped bytes. The cascade
         # will pick it and returned_bytes_differ will be True.
         good_crop = self._card_bytes()
-        monkeypatch.setattr("app.cropper.pil_trim.trim", lambda _b: good_crop)
+        monkeypatch.setattr("app.cropper.pil_trim.trim_dark", lambda _b: good_crop)
 
         response = client.post(
             "/process",
@@ -382,7 +382,7 @@ class TestPrecroppedField:
         )
         assert response.status_code == 200
         body = response.json()
-        assert body["cropped_source"] == "pil_trim"
+        assert body["cropped_source"] == "pil_trim_dark"
         assert body["cropped_image_b64"] is not None
         import base64
 


### PR DESCRIPTION
## Summary

Two refinements to the cascade landed in slice 2:

1. **Precropped flows through the same validator + text-count gate as every server-side cropper.** The previous short-circuit gave client crops a trust level the data doesn't support.

2. **Added `pil_trim_light` as a sibling strategy** for card-darker-than-background photos (white paper, light desks) — previously those fell all the way to SAM.

## Cascade order (after this PR)

1. `precropped` — client-supplied, or raw image as fallback
2. `pil_trim_dark` — renamed from `trim` (card lighter than bg)
3. `pil_trim_light` — NEW (card darker than bg)
4. `sam`
5. `haiku_bbox`
6. `passthrough`

All 5 non-passthrough stages flow through the same `_try_stage` wrapper.

## Cost

+1 Vision call on the happy path (~\$0.0015, ~500ms) because the baseline orient is now computed up front so the text-count gate can apply to precropped too. You explicitly flagged "more accurate is better" — that's the trade.

## API change

`cropped_source` enum gains `\"pil_trim_dark\"` + `\"pil_trim_light\"` in place of `\"pil_trim\"`. script-frontend only reads `player`/`team`/`card_number`/`side` so no client impact.

## Tests

- `test_cropper_pil_trim.py` parameterized over both variants (dark/light) × all happy-path assertions
- `test_cropper_cascade.py` restructured: validator-fails / text-count-gate-fails / pil_trim_light-wins / all-fail-passthrough
- `test_process_route.py` + smoke + integration shape-checks updated
- OpenAPI snapshot regenerated
- 131 unit tests, 88.7% coverage

## Test plan

- [ ] `test` + `deploy-preview` + `preview-smoke` green.
- [ ] Merge → full prod pipeline green.
- [ ] Post-deploy manual check against a white-background fixture: response `cropped_source` == `\"pil_trim_light\"`, `cropped_image_b64` populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)