### PR TITLE
feat(fixtures): wire fetch_fixtures.py + add push_fixtures.py

### DIFF
--- a/scripts/fetch_fixtures.py
+++ b/scripts/fetch_fixtures.py
@@ -1,40 +1,137 @@
 #!/usr/bin/env python3
 """Download fixture images from GCS.
 
-TODO(terraform): wire up once `gs://neonbinder-dev-preprocess-fixtures` exists.
-Blocked on the trunk-based conversion of `neonbinder_terraform/` finishing;
-creating the bucket requires Terraform per project policy (no out-of-band
-GCP resource creation).
+Fixture images (real card photos, 22–26 MB each) are too large to commit
+to git. Only the YAML expectation sidecars live in the repo; the images
+sit in `gs://neonbinder-dev-preprocess-fixtures` (provisioned by
+`neonbinder_terraform`, dev project only).
 
-Until then, fixture images are obtained manually — see
-`tests/fixtures/README.md`. This script exists as a placeholder so the path
-forward is discoverable from the repo.
+Usage:
+    python scripts/fetch_fixtures.py        # download every missing image
+    python scripts/fetch_fixtures.py --force  # re-download even if present
+    python scripts/fetch_fixtures.py --dry-run  # list what would be fetched
 
-Planned behavior:
-    1. Read `tests/fixtures/*.yaml` to discover which images are referenced.
-    2. Check which image files are missing locally.
-    3. For each missing image, `gsutil cp` from the bucket. Use ADC; the
-       developer's Owner creds on neonbinder-dev are sufficient.
-    4. Report anything that failed to download with a clear error.
+Uses `gcloud storage cp`. Requires ADC (`gcloud auth application-default
+login`) from a user with `roles/storage.objectViewer` on the bucket —
+any of the configured `developer_emails` in terraform has this via
+`roles/storage.objectAdmin`, and the preprocess runtime SA has it via
+`roles/storage.objectViewer` (for future CI integration-test jobs).
+
+What counts as "a fixture"?
+    Every `.yaml` sidecar in `tests/fixtures/` implies a matching image
+    with the same stem. Supported extensions: .jpg, .jpeg, .png, .webp.
+    The script tries each extension in order and downloads the first
+    one that exists in the bucket.
+
+Companion upload:
+    gcloud storage cp tests/fixtures/NAME.EXT gs://neonbinder-dev-preprocess-fixtures/NAME.EXT
+
+See `tests/fixtures/README.md` for the full add-a-new-fixture workflow.
 """
 
 from __future__ import annotations
 
+import argparse
+import subprocess
 import sys
+from pathlib import Path
 
-FIXTURES_BUCKET: str | None = None  # set once Terraform creates the bucket
+FIXTURES_BUCKET = "gs://neonbinder-dev-preprocess-fixtures"
+FIXTURES_DIR = Path(__file__).resolve().parent.parent / "tests" / "fixtures"
+SUPPORTED_EXTS = (".jpg", ".jpeg", ".png", ".webp")
+
+
+def _sidecar_stems() -> list[str]:
+    """All `.yaml` sidecar stems in tests/fixtures/."""
+    return sorted(p.stem for p in FIXTURES_DIR.iterdir() if p.is_file() and p.suffix == ".yaml")
+
+
+def _local_image_for(stem: str) -> Path | None:
+    """Return the existing local image for a given stem, or None."""
+    for ext in SUPPORTED_EXTS:
+        p = FIXTURES_DIR / f"{stem}{ext}"
+        if p.exists():
+            return p
+    return None
+
+
+def _remote_object_for(stem: str) -> str | None:
+    """Find the first extension that exists in the bucket. None if nothing found."""
+    for ext in SUPPORTED_EXTS:
+        uri = f"{FIXTURES_BUCKET}/{stem}{ext}"
+        result = subprocess.run(
+            ["gcloud", "storage", "ls", uri],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return uri
+    return None
+
+
+def _download(uri: str, dest: Path) -> bool:
+    """Run `gcloud storage cp URI DEST`. Returns True on success."""
+    result = subprocess.run(
+        ["gcloud", "storage", "cp", uri, str(dest)],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        print(f"  ERROR: {result.stderr.strip() or result.stdout.strip()}", file=sys.stderr)
+        return False
+    return True
 
 
 def main() -> int:
-    if FIXTURES_BUCKET is None:
-        print(
-            "Fixture bucket not yet provisioned. See tests/fixtures/README.md "
-            "for the manual-copy workflow. This script will be wired up once "
-            "the Terraform trunk-based conversion lands."
-        )
-        return 1
-    # Implementation deferred until bucket exists.
-    return 0
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="re-download even when the local image already exists",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print what would be fetched without downloading",
+    )
+    args = parser.parse_args()
+
+    stems = _sidecar_stems()
+    if not stems:
+        print(f"No .yaml sidecars in {FIXTURES_DIR} — nothing to fetch.")
+        return 0
+
+    print(f"{len(stems)} sidecar(s) under {FIXTURES_DIR}")
+    downloaded = 0
+    missing = 0
+    skipped = 0
+
+    for stem in stems:
+        local = _local_image_for(stem)
+        if local is not None and not args.force:
+            print(f"  {stem}: already present ({local.name})")
+            skipped += 1
+            continue
+
+        remote = _remote_object_for(stem)
+        if remote is None:
+            print(f"  {stem}: no image found in {FIXTURES_BUCKET}", file=sys.stderr)
+            missing += 1
+            continue
+
+        ext = Path(remote).suffix
+        dest = FIXTURES_DIR / f"{stem}{ext}"
+        print(f"  {stem}: fetch {remote} → {dest.name}")
+        if args.dry_run:
+            continue
+        if _download(remote, dest):
+            downloaded += 1
+
+    print(
+        f"\nsummary: {downloaded} downloaded, {skipped} already present, "
+        f"{missing} missing from bucket"
+    )
+    return 1 if missing > 0 else 0
 
 
 if __name__ == "__main__":

--- a/scripts/push_fixtures.py
+++ b/scripts/push_fixtures.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Upload local fixture images to the GCS bucket.
+
+Counterpart to `scripts/fetch_fixtures.py`. Use when adding a new
+fixture: drop the image into `tests/fixtures/`, run the label script to
+bootstrap a sidecar, then push the image here so other devs + future CI
+can fetch it.
+
+Usage:
+    python scripts/push_fixtures.py                # upload every image
+    python scripts/push_fixtures.py --only NAME   # upload one (stem, e.g. "landscape")
+    python scripts/push_fixtures.py --dry-run     # list what would be uploaded
+
+Requires ADC with `roles/storage.objectAdmin` on
+`gs://neonbinder-dev-preprocess-fixtures` — `developer_emails` in
+neonbinder_terraform/environments/dev.tfvars have this.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+FIXTURES_BUCKET = "gs://neonbinder-dev-preprocess-fixtures"
+FIXTURES_DIR = Path(__file__).resolve().parent.parent / "tests" / "fixtures"
+SUPPORTED_EXTS = (".jpg", ".jpeg", ".png", ".webp")
+
+
+def _local_images() -> list[Path]:
+    return sorted(
+        p for p in FIXTURES_DIR.iterdir() if p.is_file() and p.suffix.lower() in SUPPORTED_EXTS
+    )
+
+
+def _upload(src: Path) -> bool:
+    uri = f"{FIXTURES_BUCKET}/{src.name}"
+    result = subprocess.run(
+        ["gcloud", "storage", "cp", str(src), uri],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        print(f"  ERROR: {result.stderr.strip() or result.stdout.strip()}", file=sys.stderr)
+        return False
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--only",
+        help="upload only the image whose stem matches (no extension)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print what would be uploaded without actually pushing",
+    )
+    args = parser.parse_args()
+
+    images = _local_images()
+    if args.only:
+        images = [p for p in images if p.stem == args.only]
+        if not images:
+            print(f"No local image with stem {args.only!r} under {FIXTURES_DIR}")
+            return 1
+
+    if not images:
+        print(f"No images under {FIXTURES_DIR} — nothing to upload.")
+        return 0
+
+    print(f"uploading {len(images)} image(s) to {FIXTURES_BUCKET}")
+    uploaded = 0
+    for src in images:
+        print(f"  {src.name} ({src.stat().st_size:,} bytes)")
+        if args.dry_run:
+            continue
+        if _upload(src):
+            uploaded += 1
+
+    print(f"\nsummary: {uploaded} uploaded")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -1,42 +1,62 @@
 # Fixture images
 
-Binary images are stored out-of-band. Only the `.yaml` sidecars are tracked in
-git. The sidecars declare expected orient + classify outputs per image; see
-`tests/integration/_loader.py` for the schema.
+Binary images are stored in GCS — they're 22–26 MB phone-camera shots and
+would bloat the git repo. Only the `.yaml` sidecars live in git; the
+sidecars declare expected orient + classify outputs per image. See
+`tests/integration/_loader.py` for the sidecar schema.
 
-## Getting images
+## Bucket
 
-Currently manual — drop the matching image file next to each tracked sidecar:
+`gs://neonbinder-dev-preprocess-fixtures` — provisioned by
+`neonbinder_terraform`, dev project only. Access:
 
+- `developer_emails` (from `dev.tfvars`): `roles/storage.objectAdmin`
+  (upload + read + delete)
+- `preprocess_runtime` SA: `roles/storage.objectViewer`
+- `preprocess_deployer` SA: `roles/storage.objectViewer`
+
+Versioning is on; fixture replacements are auditable.
+
+## Fetching images (first run on a new machine)
+
+```bash
+gcloud auth application-default login   # one-time per machine
+python scripts/fetch_fixtures.py
 ```
-tests/fixtures/
-  black-border-back.jpg    ← not in git, drop here
-  black-border-back.yaml   ← in git, already here
-  landscape.jpg
-  landscape.yaml
-  white-border-front.jpg
-  white-border-front.yaml
-```
 
-Ask `@jburich` for a copy of the current fixture set (they live on his Mac
-for now).
+The script reads every `.yaml` sidecar and downloads the matching image
+(tries `.jpg`, `.jpeg`, `.png`, `.webp` in that order) if not already
+present locally.
 
-## Planned (pending Terraform work)
+Flags:
 
-Once `neonbinder_terraform/` is done with the trunk-based conversion, we'll
-add a GCS bucket `gs://neonbinder-dev-preprocess-fixtures` and
-`scripts/fetch_fixtures.py` will pull missing images from it automatically
-before tests run.
+- `--force` — re-download even when the local image already exists
+- `--dry-run` — print what would be fetched without downloading
 
 ## Adding a new fixture
 
-1. Drop the image next to the other fixtures (any of `.jpg`, `.jpeg`, `.png`,
-   `.webp`).
-2. Run `python scripts/label_fixtures.py --fixture <name>.jpg` to bootstrap a
-   sidecar from a real pipeline run.
+1. Drop the new image into `tests/fixtures/` (any of `.jpg`, `.jpeg`,
+   `.png`, `.webp`).
+2. Run `python scripts/label_fixtures.py --fixture <name>.jpg` to bootstrap
+   a sidecar from a real pipeline run.
 3. Review the generated sidecar. Loosen `equals:` to `contains:` on
-   player/team if the exact string is likely to drift. Delete fields you
-   don't want to assert. Card_number stays exact per project policy.
-4. Commit the sidecar (image stays local / out-of-band).
-5. Run `RUN_INTEGRATION_TESTS=1 pytest tests/integration -v` to confirm the
-   sidecar passes.
+   `player`/`team` where Haiku drift is expected. Delete fields you don't
+   want to assert. `card_number` stays exact per project policy.
+4. `python scripts/push_fixtures.py --only <name>` to upload the image.
+5. `git add tests/fixtures/<name>.yaml && git commit` — only the sidecar is
+   tracked.
+6. `RUN_INTEGRATION_TESTS=1 pytest tests/integration -v` to confirm the
+   sidecar's assertions pass against the deployed pipeline.
+
+## Replacing an existing fixture
+
+Versioning is on, so overwriting is safe — the previous version stays in
+the bucket as a non-current copy for up to a year. Workflow:
+
+```bash
+# swap the local file
+cp /path/to/new/image.jpg tests/fixtures/<name>.jpg
+python scripts/push_fixtures.py --only <name>
+# regenerate the sidecar if classify results differ
+python scripts/label_fixtures.py --fixture <name>.jpg --force
+```


### PR DESCRIPTION
## Summary

Closes the loop on slice 1.5's deferred fixture bucket. Replaces the `scripts/fetch_fixtures.py` stub with a real implementation against `gs://neonbinder-dev-preprocess-fixtures` (provisioned by ioc#11) and adds a companion `scripts/push_fixtures.py` for adding new fixtures.

## Scripts

**`scripts/fetch_fixtures.py`** — scans `.yaml` sidecars in `tests/fixtures/`, checks the bucket for each stem + supported extension, downloads whatever's missing. Flags: `--force`, `--dry-run`. Non-zero exit if any sidecar has no matching image in the bucket (CI-friendly).

**`scripts/push_fixtures.py`** — uploads every local image (or just one via `--only <stem>`) to the bucket. Also `--dry-run`.

Both use `gcloud storage cp` so auth is one-hop ADC.

## Docs

`tests/fixtures/README.md` rewritten:
- First-run fetch workflow: `gcloud auth application-default login` once, then `python scripts/fetch_fixtures.py`.
- Add-a-new-fixture: drop image → label → push → commit sidecar.
- Replace-an-existing leveraging bucket versioning.

## Follow-up

After merge, I (or you) need to upload the 3 existing local fixtures (`landscape.jpg`, `white-border-front.jpg`, `black-border-back.jpg`) via `python scripts/push_fixtures.py`. My local gcloud auth expired so I couldn't do it from here; happy to do it if you refresh auth via `!gcloud auth application-default login`, otherwise you can run the push command directly.

## Test plan

- [x] `pytest tests/unit` green (131 tests, 88.7% coverage — unchanged).
- [x] `ruff check + format --check` clean.
- [x] `python scripts/fetch_fixtures.py --dry-run` runs without error against the 3 existing local fixtures.
- [ ] Post-merge: upload the 3 fixtures, then run `python scripts/fetch_fixtures.py --force` on a clean clone to verify end-to-end download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)