### PR TITLE
feat(crop-only): accept crop-only uploads on /process

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,75 @@ See `../image-processing.md` in the neonbinder wrapper for the full design.
 ## Endpoints
 
 - `GET /health` — liveness probe, returns `{"status":"ok"}`.
-- `POST /process` — already-cropped image → orient + classify (slice 1, in progress).
-- `POST /crop-and-process` — raw photo → SAM crop → orient + classify (slice 2).
+- `POST /process` — image preprocessing in three modes (see below).
 
 Auth: all non-health endpoints require the `x-internal-key` header matching
 the `INTERNAL_API_KEY` env var (sourced from Secret Manager in Cloud Run).
+
+### `POST /process` modes
+
+Accepts two optional multipart file fields: `image` (the original photo)
+and `precropped` (a client-side crop of the card). At least one is
+required. The response shape is the same `ProcessResponse` for all three
+modes — the mode only affects which work the server performs.
+
+| Mode | `image` | `precropped` | What runs | When to use |
+|---|:-:|:-:|---|---|
+| **image-only** | yes | — | Full crop cascade (PIL trim → SAM → Haiku bbox → passthrough) on the original. | Callers with no client-side crop capability. |
+| **image + precropped** | yes | yes | Tries the crop first; if rejected, falls back to the full cascade on the original. | Callers that can guess a crop but want a server-side safety net. |
+| **crop-only** | — | yes | Validates the crop; on pass, runs orient + classify on it. On reject, returns 422 so the caller retries with the original. | Bandwidth-constrained callers whose client-side crops are usually good. Skips the 22 MB-per-image upload entirely when the crop passes. |
+
+On success (all modes) you get a `200` with `ProcessResponse`. Crop-only
+mode is the only mode that can return a business-logic 422.
+
+#### 422 — crop-only validation failed
+
+```json
+HTTP/1.1 422 Unprocessable Entity
+{
+  "error_code": "CROP_VALIDATION_FAILED",
+  "reason": "aspect 0.857 off by 20%",
+  "retry_with_original": true
+}
+```
+
+`reason` is one of (non-exhaustive, mirrors `ValidationResult.reason`):
+`too small WxH`, `aspect … off by N%`, `near-uniform (stddev …)`, or the
+special `insufficient_text` when Vision finds no text on the crop. Clients
+should treat `retry_with_original: true` as the directive and re-issue the
+request with the original image attached as `image`.
+
+#### 400 — missing both fields
+
+```json
+HTTP/1.1 400 Bad Request
+{
+  "error_code": "MISSING_IMAGE",
+  "detail": "at least one of image or precropped is required"
+}
+```
+
+### Client telemetry (for adopters of crop-only mode)
+
+The server emits per-request structured logs with `mode ∈ {image_only,
+image_and_crop, crop_only}` and, on crop-only rejection, the rejection
+reason. This is the authoritative signal (no sampling, covers all
+callers including the script-frontend CLI which does not run PostHog).
+
+Web/mobile callers adopting crop-only mode should additionally emit the
+following events to PostHog so the client-observed upload time (the
+dominant cost this optimization attacks) is measurable:
+
+- `preprocess_request_started` — props: `mode`, `original_bytes` (if
+  attached), `crop_bytes` (if attached).
+- `preprocess_request_completed` — props: `duration_ms` (client
+  wall-clock), `http_status`, `cropped_source`.
+- `preprocess_crop_rejected` — props: `reason`, `retrying_with_original`.
+- `preprocess_retry_completed` — props: `duration_ms`.
+
+Gate the rollout on the PostHog feature flag
+`preprocess-crop-only-enabled` so adoption can be ramped or halted
+without a code deploy.
 
 ## Local dev
 

--- a/app/cropper/__init__.py
+++ b/app/cropper/__init__.py
@@ -54,6 +54,14 @@ logger = logging.getLogger(__name__)
 # similar crops without letting a wrong-region crop slip through.
 MIN_CASCADE_TEXT_RATIO = 0.8
 
+# In crop-only mode (no original uploaded) there's no baseline to regress
+# from, so the text-count gate becomes an absolute floor: Vision must find
+# at least this many text tokens on the crop for it to be considered a card.
+# 1 is enough to distinguish blank/scenery images from cards while staying
+# permissive enough that legitimate low-text crops (e.g. backs of early
+# cards) still pass.
+MIN_ABSOLUTE_TEXT_COUNT = 1
+
 # Type for a crop strategy: takes raw image bytes, returns cropped bytes or None.
 CropStrategy = Callable[[bytes], bytes | None]
 
@@ -88,6 +96,20 @@ class CropResult:
     returned_bytes_differ: bool
     orientation: OrientationResult
     classification: ClassifyResult
+
+
+@dataclass(frozen=True)
+class CropRejected:
+    """Crop-only-mode outcome when the supplied crop fails validation.
+
+    Only produced by the crop-only code path (no `image_bytes` uploaded).
+    The handler translates this into a 422 response with a specific error
+    code so the caller knows to retry with the original image attached.
+    `reason` mirrors `ValidationResult.reason` or `"insufficient_text"`
+    from the absolute text-count floor.
+    """
+
+    reason: str
 
 
 def _try_stage(
@@ -130,21 +152,80 @@ def _try_stage(
     )
 
 
+def _try_precropped_only(precropped_bytes: bytes) -> CropResult | CropRejected:
+    """Crop-only mode: caller supplied only a crop, no original.
+
+    Two gates still apply, adapted to the missing-original constraint:
+      1. Geometry + blank-image (validator.is_plausible_crop with
+         source_area_bytes=None — area-fraction is skipped since there's
+         no source to compare against).
+      2. Absolute text-count floor (MIN_ABSOLUTE_TEXT_COUNT) in place of the
+         regression guard, since there's no baseline to regress from.
+
+    On failure returns CropRejected so the handler can surface a specific
+    4xx and the caller knows to retry with the original. On success runs
+    orient → rotate → classify on the crop and returns a normal CropResult
+    with source="precropped".
+    """
+    check = is_plausible_crop(precropped_bytes, source_area_bytes=None)
+    if not check.ok:
+        logger.info("crop_only: rejected by validator (%s)", check.reason)
+        return CropRejected(reason=check.reason or "validator_failed")
+
+    orient = detect_orientation(precropped_bytes)
+    if orient.text_count < MIN_ABSOLUTE_TEXT_COUNT:
+        logger.info(
+            "crop_only: text_count=%d below absolute floor=%d",
+            orient.text_count,
+            MIN_ABSOLUTE_TEXT_COUNT,
+        )
+        return CropRejected(reason="insufficient_text")
+
+    rotated = rotate_image_bytes(precropped_bytes, orient.rotation_degrees)
+    classification = classify_card(rotated)
+
+    return CropResult(
+        image_bytes=precropped_bytes,
+        source="precropped",
+        returned_bytes_differ=False,
+        orientation=orient,
+        classification=classification,
+    )
+
+
 def crop(
     *,
-    image_bytes: bytes,
+    image_bytes: bytes | None,
     precropped_bytes: bytes | None,
-) -> CropResult:
+) -> CropResult | CropRejected:
     """Run the crop cascade and return the winning result.
 
-    When `precropped_bytes` is provided, that's tried first via `_try_stage`.
-    When absent, the `image` upload is used as the stage-1 candidate (slice-1
-    backward compat for callers who already cropped client-side).
+    Three input modes:
+      - image-only: `image_bytes` set, `precropped_bytes` None → full cascade.
+      - image+precropped: both set → cascade with precropped as stage 1,
+        falls back to server strategies on the original if it's rejected.
+      - **crop-only**: `image_bytes` None, `precropped_bytes` set → validate
+        crop, run orient/classify on it, return CropResult or CropRejected.
+        No fallback path — handler translates CropRejected to 422.
+
+    When `precropped_bytes` is provided alongside `image_bytes`, that's tried
+    first via `_try_stage`. When only `image_bytes` is present, it's used as
+    the stage-1 candidate (slice-1 backward compat for callers who already
+    cropped client-side).
 
     The baseline orient on `image_bytes` is computed up front — one extra
     Vision call relative to the old precropped-short-circuit path — so the
     text-count gate applies uniformly to every stage, including precropped.
     """
+    # ── Crop-only mode ─────────────────────────────────────────────────
+    # Caller opted into the "don't upload the original" fast path. No
+    # fallback cascade is available; reject with a specific reason if
+    # the crop doesn't pass the adapted two-gate check.
+    if image_bytes is None:
+        if precropped_bytes is None:
+            raise ValueError("crop() requires at least one of image_bytes or precropped_bytes")
+        return _try_precropped_only(precropped_bytes)
+
     # ── Baseline — used for the text-count threshold AND as the passthrough
     # fallback orient. Computed once, reused throughout.
     baseline_orient = detect_orientation(image_bytes)

--- a/app/main.py
+++ b/app/main.py
@@ -17,10 +17,12 @@ import os
 from typing import Annotated
 
 from fastapi import FastAPI, File, Header, HTTPException, UploadFile, status
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from app import cropper
 from app.classify import ClassifyError
+from app.cropper import CropRejected
 
 logger = logging.getLogger(__name__)
 
@@ -108,16 +110,47 @@ def health() -> dict[str, str]:
 
 @app.post("/process", response_model=ProcessResponse)
 async def process(
-    image: Annotated[UploadFile, File()],
+    image: Annotated[UploadFile | None, File()] = None,
     precropped: Annotated[UploadFile | None, File()] = None,
     x_internal_key: Annotated[str | None, Header()] = None,
-) -> ProcessResponse:
+) -> ProcessResponse | JSONResponse:
+    """Preprocess an image for card identification.
+
+    Three request modes:
+      - **image-only** (unchanged default): `image` attached, no `precropped`.
+        Runs the full crop cascade on the original.
+      - **image + precropped** (unchanged opt-in): both attached. The
+        precropped is tried as the cascade's stage-1 candidate; if it's
+        rejected, the server falls back to its own crop strategies on the
+        original. Saves SAM/Haiku cost when the client crop is good; costs
+        full upload bandwidth regardless.
+      - **crop-only** (new): only `precropped` attached. Server validates the
+        crop and runs orient+classify on it if it passes. If validation
+        fails, returns `422 {"error_code":"CROP_VALIDATION_FAILED", ...,
+        "retry_with_original": true}` so the caller can retry with the
+        original. No silent server-side fallback — saving upload bandwidth
+        is the whole point.
+    """
     _verify_internal_key(x_internal_key)
 
-    image_bytes = await _read_upload(image, field="image")
+    image_bytes: bytes | None = None
     precropped_bytes: bytes | None = None
+    if image is not None:
+        image_bytes = await _read_upload(image, field="image")
     if precropped is not None:
         precropped_bytes = await _read_upload(precropped, field="precropped")
+
+    if image_bytes is None and precropped_bytes is None:
+        return JSONResponse(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            content={
+                "error_code": "MISSING_IMAGE",
+                "detail": "at least one of image or precropped is required",
+            },
+        )
+
+    mode = _request_mode(image_bytes, precropped_bytes)
+    logger.info("process: mode=%s", mode)
 
     # The cascade handles orient + rotate + classify internally so every
     # crop strategy is evaluated through the same quality gates. Upstream
@@ -138,6 +171,22 @@ async def process(
             detail="preprocess pipeline upstream failure",
         ) from None
 
+    # Crop-only mode can reject the upload with a specific reason. The
+    # handler surfaces this as 422 with a structured body so callers can
+    # distinguish "crop no good, retry with original" from server errors.
+    if isinstance(result, CropRejected):
+        logger.info("process: mode=%s crop_rejected reason=%s", mode, result.reason)
+        return JSONResponse(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            content={
+                "error_code": "CROP_VALIDATION_FAILED",
+                "reason": result.reason,
+                "retry_with_original": True,
+            },
+        )
+
+    logger.info("process: mode=%s source=%s", mode, result.source)
+
     cropped_image_b64: str | None = None
     if result.returned_bytes_differ:
         cropped_image_b64 = base64.b64encode(result.image_bytes).decode("ascii")
@@ -154,3 +203,17 @@ async def process(
         cropped_source=result.source,
         cropped_image_b64=cropped_image_b64,
     )
+
+
+def _request_mode(image_bytes: bytes | None, precropped_bytes: bytes | None) -> str:
+    """Single-word mode label for structured logging.
+
+    Matches the three-mode taxonomy in the crop-only plan; feeds Cloud
+    Logging dashboards so `mode=crop_only rejection_rate` is a
+    one-liner query.
+    """
+    if image_bytes is not None and precropped_bytes is not None:
+        return "image_and_crop"
+    if image_bytes is not None:
+        return "image_only"
+    return "crop_only"

--- a/tests/unit/openapi_snapshot.json
+++ b/tests/unit/openapi_snapshot.json
@@ -4,9 +4,16 @@
       "Body_process_process_post": {
         "properties": {
           "image": {
-            "format": "binary",
-            "title": "Image",
-            "type": "string"
+            "anyOf": [
+              {
+                "format": "binary",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image"
           },
           "precropped": {
             "anyOf": [
@@ -21,9 +28,6 @@
             "title": "Precropped"
           }
         },
-        "required": [
-          "image"
-        ],
         "title": "Body_process_process_post",
         "type": "object"
       },
@@ -195,6 +199,7 @@
     },
     "/process": {
       "post": {
+        "description": "Preprocess an image for card identification.\n\nThree request modes:\n  - **image-only** (unchanged default): `image` attached, no `precropped`.\n    Runs the full crop cascade on the original.\n  - **image + precropped** (unchanged opt-in): both attached. The\n    precropped is tried as the cascade's stage-1 candidate; if it's\n    rejected, the server falls back to its own crop strategies on the\n    original. Saves SAM/Haiku cost when the client crop is good; costs\n    full upload bandwidth regardless.\n  - **crop-only** (new): only `precropped` attached. Server validates the\n    crop and runs orient+classify on it if it passes. If validation\n    fails, returns `422 {\"error_code\":\"CROP_VALIDATION_FAILED\", ...,\n    \"retry_with_original\": true}` so the caller can retry with the\n    original. No silent server-side fallback \u2014 saving upload bandwidth\n    is the whole point.",
         "operationId": "process_process_post",
         "parameters": [
           {
@@ -221,8 +226,7 @@
                 "$ref": "#/components/schemas/Body_process_process_post"
               }
             }
-          },
-          "required": true
+          }
         },
         "responses": {
           "200": {

--- a/tests/unit/test_cropper_cascade.py
+++ b/tests/unit/test_cropper_cascade.py
@@ -19,7 +19,7 @@ from PIL import Image
 
 from app import cropper
 from app.classify import ClassifyResult
-from app.cropper import CropResult, crop
+from app.cropper import CropRejected, CropResult, crop
 from app.orient import OrientationResult
 
 
@@ -387,6 +387,97 @@ class TestPassthroughFallback:
         assert result.classification.players == []
         assert result.classification.card_number is None
         assert result.classification.side == "back"
+
+
+class TestCropOnlyMode:
+    """Crop-only mode: caller provides only `precropped_bytes`, no original.
+
+    The cascade has no fallback path here — it either returns a normal
+    CropResult (crop passed the adapted two-gate check) or a CropRejected
+    with a specific reason so main.py can surface a 422.
+    """
+
+    def test_valid_crop_returns_crop_result(self, stub_orient, stub_classify):
+        stub_orient()
+        stub_classify(_classify())
+
+        crop_bytes = _card_jpeg(size=(500, 700))
+        result = crop(image_bytes=None, precropped_bytes=crop_bytes)
+
+        assert isinstance(result, CropResult)
+        assert result.source == "precropped"
+        assert result.image_bytes == crop_bytes
+        assert result.returned_bytes_differ is False
+        assert result.classification.players == ["Ichiro"]
+
+    def test_too_small_crop_rejected(self, stub_orient, stub_classify):
+        # Orient/classify stubs set but shouldn't be reached on validator reject.
+        orient_calls = stub_orient()
+        classify_calls = stub_classify(_classify())
+
+        tiny = _card_jpeg(size=(100, 140))
+        result = crop(image_bytes=None, precropped_bytes=tiny)
+
+        assert isinstance(result, CropRejected)
+        assert "too small" in result.reason
+        assert orient_calls == []  # no orient on a validator-rejected crop
+        assert classify_calls == []
+
+    def test_wrong_aspect_rejected(self, stub_orient, stub_classify):
+        stub_orient()
+        stub_classify(_classify())
+
+        square = _card_jpeg(size=(600, 600))
+        result = crop(image_bytes=None, precropped_bytes=square)
+
+        assert isinstance(result, CropRejected)
+        assert "aspect" in result.reason
+
+    def test_insufficient_text_rejected(self, stub_orient, stub_classify):
+        # Crop passes geometry but Vision finds no text — treat as not-a-card.
+        stub_orient(_orient(text_count=0))
+        classify_calls = stub_classify(_classify())
+
+        crop_bytes = _card_jpeg(size=(500, 700))
+        result = crop(image_bytes=None, precropped_bytes=crop_bytes)
+
+        assert isinstance(result, CropRejected)
+        assert result.reason == "insufficient_text"
+        # classify must not run when the crop is rejected upstream
+        assert classify_calls == []
+
+    def test_blank_image_rejected(self, stub_orient, stub_classify):
+        stub_orient()
+        stub_classify(_classify())
+
+        # Solid white passes geometry but fails the stddev check.
+        buf = io.BytesIO()
+        Image.new("RGB", (500, 700), color="white").save(buf, format="JPEG")
+        blank = buf.getvalue()
+
+        result = crop(image_bytes=None, precropped_bytes=blank)
+
+        assert isinstance(result, CropRejected)
+        assert "near-uniform" in result.reason
+
+    def test_both_none_raises(self):
+        with pytest.raises(ValueError, match="at least one"):
+            crop(image_bytes=None, precropped_bytes=None)
+
+    def test_rotation_applied_before_classify(self, stub_orient, stub_classify):
+        # Sanity: crop-only path still rotates the crop before classify.
+        stub_orient(_orient(rotation=90))
+        classify_calls = stub_classify(_classify())
+
+        # Valid card-ratio crop so it passes validator.
+        crop_bytes = _card_jpeg(size=(500, 700))
+        result = crop(image_bytes=None, precropped_bytes=crop_bytes)
+
+        assert isinstance(result, CropResult)
+        assert len(classify_calls) == 1
+        # After CCW-90, the 500x700 crop should be seen by classify as 700x500.
+        with Image.open(io.BytesIO(classify_calls[0])) as rotated:
+            assert rotated.size == (700, 500)
 
 
 class TestCropResultShape:

--- a/tests/unit/test_process_route.py
+++ b/tests/unit/test_process_route.py
@@ -131,12 +131,15 @@ class TestRequestValidation:
         )
         assert response.status_code == 413
 
-    def test_missing_file_field_returns_422(self):
+    def test_missing_file_field_returns_400_missing_image(self):
+        """With image+precropped both optional, an empty request is a
+        MISSING_IMAGE 400 rather than a FastAPI-level 422."""
         response = client.post(
             "/process",
             headers={"x-internal-key": "test-key"},
         )
-        assert response.status_code == 422
+        assert response.status_code == 400
+        assert response.json()["error_code"] == "MISSING_IMAGE"
 
 
 class TestUpstreamFailures:
@@ -387,3 +390,132 @@ class TestPrecroppedField:
         import base64
 
         assert base64.b64decode(body["cropped_image_b64"]) == good_crop
+
+
+class TestCropOnlyMode:
+    """Crop-only mode: caller uploads only `precropped`, no `image`.
+
+    Cuts upload bandwidth (the dominant client-observed cost) by letting
+    callers skip the original when their client-side crop is good. On
+    validator reject the handler returns 422 with a specific error code
+    so the caller can retry with the original attached.
+    """
+
+    @staticmethod
+    def _card_bytes(size: tuple[int, int] = (500, 700)) -> bytes:
+        import random
+
+        rng = random.Random(size[0] + size[1])
+        raw = bytes(rng.randint(0, 255) for _ in range(size[0] * size[1] * 3))
+        out = io.BytesIO()
+        Image.frombytes("RGB", size, raw).save(out, format="JPEG", quality=85)
+        return out.getvalue()
+
+    def test_valid_crop_only_returns_200_precropped(self, monkeypatch):
+        _stub_orient(monkeypatch, rotation=0, confidence=0.9, text_count=12)
+        classify_inputs = _stub_classify(monkeypatch, player="Jeter", team="Yankees")
+
+        crop = self._card_bytes()
+        response = client.post(
+            "/process",
+            headers={"x-internal-key": "test-key"},
+            files={"precropped": ("crop.jpg", crop, "image/jpeg")},
+        )
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["cropped_source"] == "precropped"
+        # Caller already has the bytes — never echo them back in crop-only mode.
+        assert body["cropped_image_b64"] is None
+        assert body["players"] == ["Jeter"]
+        assert body["team"] == "Yankees"
+        # Orient ran exactly once (on the crop) — crop-only skips the
+        # baseline-orient call the full cascade makes on the original.
+        assert len(classify_inputs) == 1
+
+    def test_too_small_crop_returns_422(self, monkeypatch):
+        _stub_orient(monkeypatch)
+        _stub_classify(monkeypatch)
+
+        response = client.post(
+            "/process",
+            headers={"x-internal-key": "test-key"},
+            files={
+                # 100x140 passes content-type but fails validator min-side=300.
+                "precropped": ("crop.jpg", _jpeg((100, 140)), "image/jpeg"),
+            },
+        )
+
+        assert response.status_code == 422
+        body = response.json()
+        assert body["error_code"] == "CROP_VALIDATION_FAILED"
+        assert body["retry_with_original"] is True
+        assert "too small" in body["reason"]
+
+    def test_wrong_aspect_crop_returns_422(self, monkeypatch):
+        _stub_orient(monkeypatch)
+        _stub_classify(monkeypatch)
+
+        response = client.post(
+            "/process",
+            headers={"x-internal-key": "test-key"},
+            files={
+                # Square 600x600 passes min-size but fails aspect tolerance.
+                "precropped": ("crop.jpg", self._card_bytes((600, 600)), "image/jpeg"),
+            },
+        )
+
+        assert response.status_code == 422
+        body = response.json()
+        assert body["error_code"] == "CROP_VALIDATION_FAILED"
+        assert "aspect" in body["reason"]
+
+    def test_insufficient_text_returns_422(self, monkeypatch):
+        # Geometry is fine, but Vision returns text_count=0 → treat as not-a-card.
+        _stub_orient(monkeypatch, text_count=0)
+        _stub_classify(monkeypatch)
+
+        response = client.post(
+            "/process",
+            headers={"x-internal-key": "test-key"},
+            files={"precropped": ("crop.jpg", self._card_bytes(), "image/jpeg")},
+        )
+
+        assert response.status_code == 422
+        body = response.json()
+        assert body["error_code"] == "CROP_VALIDATION_FAILED"
+        assert body["reason"] == "insufficient_text"
+
+    def test_missing_both_fields_returns_400_missing_image(self):
+        response = client.post(
+            "/process",
+            headers={"x-internal-key": "test-key"},
+            data={"dummy": "ignored"},  # forces a multipart body without files
+        )
+        assert response.status_code == 400
+        body = response.json()
+        assert body["error_code"] == "MISSING_IMAGE"
+
+    def test_crop_only_wrong_content_type_returns_415(self, monkeypatch):
+        _stub_orient(monkeypatch)
+        _stub_classify(monkeypatch)
+
+        response = client.post(
+            "/process",
+            headers={"x-internal-key": "test-key"},
+            files={"precropped": ("crop.txt", b"not an image", "text/plain")},
+        )
+        assert response.status_code == 415
+        assert "precropped" in response.json()["detail"]
+
+    def test_crop_only_empty_returns_400(self, monkeypatch):
+        _stub_orient(monkeypatch)
+        _stub_classify(monkeypatch)
+
+        response = client.post(
+            "/process",
+            headers={"x-internal-key": "test-key"},
+            files={"precropped": ("crop.jpg", b"", "image/jpeg")},
+        )
+        assert response.status_code == 400
+        assert "empty precropped" in response.json()["detail"]


### PR DESCRIPTION
## Summary
- Adds a third request mode to `POST /process`: **crop-only** — caller uploads only `precropped`, no `image`. Server validates the crop and, if good, runs orient + classify on it directly.
- On crop reject: returns `422 {"error_code":"CROP_VALIDATION_FAILED","reason":"…","retry_with_original":true}` so the caller can retry with the original attached.
- Existing **image-only** and **image + precropped** modes are unchanged — this is purely additive. OpenAPI snapshot updated accordingly.

## Why
The 20-thread `script-frontend` workload pushes 22 MB originals across residential uplinks; upload time dominates client-observed latency (~3 min per image on the wire) and is bigger than the entire server pipeline combined. Client-side cropping already exists in the macOS path, so crop-only mode lets it upload the 2–3 MB crop directly and skip the server's cascade (plus the baseline-Vision call and the SAM cold-start tax) entirely when the crop is good.

Full diagnosis: `todos/preprocess-timeout-diagnosis-2026-04-22.md` in the wrapper repo.

## Validator adjustments for crop-only mode
- `is_plausible_crop(precropped, source_area_bytes=None)` — skips the ≥10% source-area check, keeps geometry + stddev (same code path the validator already supports).
- Text-count *regression* guard replaced with an **absolute floor** (`MIN_ABSOLUTE_TEXT_COUNT=1`, new): since there's no original to regress from, we require Vision to find at least one text token. A crop with zero text is almost certainly not a card.

## Contract details
| Mode | `image` | `precropped` | Result |
|---|:-:|:-:|---|
| image-only (today) | yes | — | full cascade on original |
| image + precropped (today) | yes | yes | precropped stage-1, cascade fallback |
| **crop-only (new)** | — | yes | 200 on pass; 422 `CROP_VALIDATION_FAILED` on reject |
| neither | — | — | 400 `MISSING_IMAGE` |

## Test plan
- [x] `ruff check` + `ruff format --check` clean
- [x] `pytest tests/unit` — 145 tests, all green (14 new: 7 route-level, 7 cropper-level)
- [x] OpenAPI snapshot regenerated (`image` becomes `anyOf[binary|null]`, body no longer `required`)
- [ ] PR preview deploy succeeds
- [ ] Preview smoke tests pass
- [ ] Manual: crop-only with a good card crop → 200 with `cropped_source: "precropped"`, `cropped_image_b64: null`
- [ ] Manual: tiny/blank/wrong-aspect crop → 422 with a matching `reason` and `retry_with_original: true`
- [ ] Manual: existing image-only request path unchanged

## Known follow-ups (not in this PR)
- `logger.info("mode=…")` lines added to `main.py` are not emitting to Cloud Run stderr — uvicorn doesn't attach handlers to the `app.main`/`app.cropper` named loggers by default. This will make it hard to diagnose 422 rejections on the deployed service. Filing a follow-up PR with the handler/log-config fix before any real rollout.
- Infra: `preprocess_max_instances` still at 3 in Terraform. Recommended bump to 20 in the same diagnosis doc is independent and not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)