### PR TITLE
feat(crop): expose /crop endpoint for picking cascade alternatives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,8 @@ tests/fixtures/*.jpg
 tests/fixtures/*.jpeg
 tests/fixtures/*.png
 tests/fixtures/*.webp
+
+# Local convenience scripts for tailing Cloud Run logs — not part of the
+# committed toolchain.
+scripts/logs.sh
+scripts/logs-tail.sh

--- a/app/cropper/__init__.py
+++ b/app/cropper/__init__.py
@@ -102,8 +102,7 @@ def resolve_strategy_identifier(identifier: str | int) -> str:
     """
     if isinstance(identifier, bool):  # bool is an int subclass — exclude it
         raise UnknownStrategyError(
-            f"invalid strategy identifier: {identifier!r}; "
-            f"valid names: {list(STRATEGY_NAMES)}"
+            f"invalid strategy identifier: {identifier!r}; " f"valid names: {list(STRATEGY_NAMES)}"
         )
     if isinstance(identifier, int):
         if 0 <= identifier < len(STRATEGY_NAMES):
@@ -132,9 +131,7 @@ def resolve_strategy_identifier(identifier: str | int) -> str:
         raise UnknownStrategyError(
             f"unknown strategy {identifier!r}; valid names: {list(STRATEGY_NAMES)}"
         )
-    raise UnknownStrategyError(
-        f"invalid strategy identifier type: {type(identifier).__name__}"
-    )
+    raise UnknownStrategyError(f"invalid strategy identifier type: {type(identifier).__name__}")
 
 
 def _strategy_callable(name: str) -> CropStrategy:
@@ -148,14 +145,10 @@ def _strategy_callable(name: str) -> CropStrategy:
     for entry_name, module, attr in _STRATEGIES:
         if entry_name == name:
             return getattr(module, attr)  # type: ignore[no-any-return]
-    raise UnknownStrategyError(
-        f"unknown strategy {name!r}; valid names: {list(STRATEGY_NAMES)}"
-    )
+    raise UnknownStrategyError(f"unknown strategy {name!r}; valid names: {list(STRATEGY_NAMES)}")
 
 
-def run_strategy_capturing(
-    name: str, image_bytes: bytes
-) -> tuple[bytes | None, str | None]:
+def run_strategy_capturing(name: str, image_bytes: bytes) -> tuple[bytes | None, str | None]:
     """Run a single strategy, capturing exceptions as a class-name string.
 
     Returns `(produced_bytes, error_class_name)`:

--- a/app/cropper/__init__.py
+++ b/app/cropper/__init__.py
@@ -80,6 +80,110 @@ _STRATEGIES: list[tuple[str, object, str]] = [
     ("haiku_bbox", haiku_bbox, "haiku_bbox_crop"),
 ]
 
+# Public, ordered tuple of strategy names. Both the cascade and the
+# /crop endpoint walk this — single source of truth for ordering.
+STRATEGY_NAMES: tuple[str, ...] = tuple(name for name, _module, _attr in _STRATEGIES)
+
+
+class UnknownStrategyError(ValueError):
+    """Raised when a strategy identifier (name or index) doesn't resolve."""
+
+
+def resolve_strategy_identifier(identifier: str | int) -> str:
+    """Resolve a strategy name or 0-based index to its canonical name.
+
+    Accepts:
+      - a strategy name string (e.g. "sam") — returned as-is if valid
+      - an int index into STRATEGY_NAMES (e.g. 2)
+      - a numeric string interpreted as an index (e.g. "2")
+
+    Raises UnknownStrategyError on unknown name, out-of-range index,
+    negative index, or non-numeric junk.
+    """
+    if isinstance(identifier, bool):  # bool is an int subclass — exclude it
+        raise UnknownStrategyError(
+            f"invalid strategy identifier: {identifier!r}; "
+            f"valid names: {list(STRATEGY_NAMES)}"
+        )
+    if isinstance(identifier, int):
+        if 0 <= identifier < len(STRATEGY_NAMES):
+            return STRATEGY_NAMES[identifier]
+        raise UnknownStrategyError(
+            f"strategy index {identifier} out of range; "
+            f"valid indices: 0..{len(STRATEGY_NAMES) - 1}"
+        )
+    if isinstance(identifier, str):
+        if identifier in STRATEGY_NAMES:
+            return identifier
+        # Numeric string → index
+        stripped = identifier.strip()
+        if stripped.lstrip("-").isdigit():
+            try:
+                idx = int(stripped)
+            except ValueError:
+                pass
+            else:
+                if 0 <= idx < len(STRATEGY_NAMES):
+                    return STRATEGY_NAMES[idx]
+                raise UnknownStrategyError(
+                    f"strategy index {idx} out of range; "
+                    f"valid indices: 0..{len(STRATEGY_NAMES) - 1}"
+                )
+        raise UnknownStrategyError(
+            f"unknown strategy {identifier!r}; valid names: {list(STRATEGY_NAMES)}"
+        )
+    raise UnknownStrategyError(
+        f"invalid strategy identifier type: {type(identifier).__name__}"
+    )
+
+
+def _strategy_callable(name: str) -> CropStrategy:
+    """Look up the strategy callable fresh on every call.
+
+    Tests rely on monkey-patching the module attribute (e.g.
+    `monkeypatch.setattr(cropper.sam, "sam_crop", ...)`) and expect the
+    cascade to pick up the patch, so we resolve via `getattr` here rather
+    than capturing the function object at import time.
+    """
+    for entry_name, module, attr in _STRATEGIES:
+        if entry_name == name:
+            return getattr(module, attr)  # type: ignore[no-any-return]
+    raise UnknownStrategyError(
+        f"unknown strategy {name!r}; valid names: {list(STRATEGY_NAMES)}"
+    )
+
+
+def run_strategy_capturing(
+    name: str, image_bytes: bytes
+) -> tuple[bytes | None, str | None]:
+    """Run a single strategy, capturing exceptions as a class-name string.
+
+    Returns `(produced_bytes, error_class_name)`:
+      - success → (bytes, None)
+      - strategy returned None → (None, None)
+      - strategy raised → (None, "<ExcClass>"); a warning is logged
+
+    Lets `/crop` distinguish "ran cleanly, found nothing" from "crashed".
+    """
+    fn = _strategy_callable(name)
+    try:
+        produced = fn(image_bytes)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("strategy %s raised %s", name, exc)
+        return None, type(exc).__name__
+    return produced, None
+
+
+def run_strategy(name: str, image_bytes: bytes) -> bytes | None:
+    """Run a single strategy. Cascade-flavored: errors are swallowed to None.
+
+    Thin wrapper over `run_strategy_capturing` that throws away the error
+    name. This is the primitive the cascade loop uses; the /crop endpoint
+    calls `run_strategy_capturing` directly so it can surface crashes.
+    """
+    produced, _err = run_strategy_capturing(name, image_bytes)
+    return produced
+
 
 @dataclass(frozen=True)
 class CropResult:
@@ -251,13 +355,8 @@ def crop(
         return result
 
     # ── Stages 2..N — server-side croppers through the same uniform gate.
-    for source, module, fn_name in _STRATEGIES:
-        strategy_fn: CropStrategy = getattr(module, fn_name)
-        try:
-            produced = strategy_fn(image_bytes)
-        except Exception as exc:  # noqa: BLE001
-            logger.warning("cascade: %s raised %s", source, exc)
-            continue
+    for source in STRATEGY_NAMES:
+        produced = run_strategy(source, image_bytes)
         if produced is None:
             continue
 

--- a/app/main.py
+++ b/app/main.py
@@ -16,13 +16,13 @@ import logging
 import os
 from typing import Annotated
 
-from fastapi import FastAPI, File, Header, HTTPException, UploadFile, status
+from fastapi import FastAPI, File, Form, Header, HTTPException, UploadFile, status
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from app import cropper
 from app.classify import ClassifyError
-from app.cropper import CropRejected
+from app.cropper import STRATEGY_NAMES, CropRejected, UnknownStrategyError
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +31,35 @@ app = FastAPI(title="neonbinder-preprocess", version="0.3.0")
 INTERNAL_API_KEY_ENV = "INTERNAL_API_KEY"
 MAX_IMAGE_BYTES = 32 * 1024 * 1024
 ALLOWED_CONTENT_TYPES = frozenset({"image/jpeg", "image/png", "image/webp"})
+
+
+class CropStrategyOutput(BaseModel):
+    """One strategy's output in a /crop response.
+
+    `image_b64` is null when the strategy returned None (ran cleanly but
+    couldn't produce a crop) OR when it raised. The two cases are
+    distinguished by `error`: null means "ran cleanly, no crop"; a string
+    is the exception class name. Crashes do NOT 5xx the endpoint — the
+    whole point of /crop is letting the human pick from whatever
+    succeeded, even when one strategy is broken.
+    """
+
+    strategy: str
+    index: int
+    image_b64: str | None
+    error: str | None
+
+
+class CropResponse(BaseModel):
+    """Response body for POST /crop.
+
+    `crops` is a list with one entry per strategy that was run:
+      - one entry when `strategy` was supplied
+      - len(STRATEGY_NAMES) entries when it was omitted
+    Order matches `cropper.STRATEGY_NAMES` (the canonical cascade order).
+    """
+
+    crops: list[CropStrategyOutput]
 
 
 class ProcessResponse(BaseModel):
@@ -217,3 +246,65 @@ def _request_mode(image_bytes: bytes | None, precropped_bytes: bytes | None) -> 
     if image_bytes is not None:
         return "image_only"
     return "crop_only"
+
+
+@app.post("/crop", response_model=CropResponse)
+async def crop_alternatives(
+    image: Annotated[UploadFile, File()],
+    strategy: Annotated[str | None, Form()] = None,
+    x_internal_key: Annotated[str | None, Header()] = None,
+) -> CropResponse | JSONResponse:
+    """Run one or all crop strategies on an uploaded image and return raw crops.
+
+    Companion to `/process`: when the cascade's "best" pick looks wrong to
+    a human, this endpoint surfaces the alternatives. No orient, no
+    classify, no gates — just raw cropped bytes per strategy so a human
+    can pick a different one. If they pick one, they re-POST it to
+    `/process` as `precropped` to get the full pipeline.
+
+    Strategy identifier (form field):
+      - omitted → run every strategy in cascade order
+      - name (e.g. `sam`) → run just that one
+      - 0-based index as a numeric string (e.g. `2`) → run just that one
+    """
+    _verify_internal_key(x_internal_key)
+
+    image_bytes = await _read_upload(image, field="image")
+
+    if strategy is not None:
+        try:
+            resolved = cropper.resolve_strategy_identifier(strategy)
+        except UnknownStrategyError as exc:
+            return JSONResponse(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                content={
+                    "error_code": "UNKNOWN_STRATEGY",
+                    "detail": str(exc),
+                    "valid": list(STRATEGY_NAMES),
+                },
+            )
+        names: tuple[str, ...] = (resolved,)
+    else:
+        names = STRATEGY_NAMES
+
+    crops: list[CropStrategyOutput] = []
+    for name in names:
+        produced, error = cropper.run_strategy_capturing(name, image_bytes)
+        image_b64 = base64.b64encode(produced).decode("ascii") if produced else None
+        crops.append(
+            CropStrategyOutput(
+                strategy=name,
+                index=STRATEGY_NAMES.index(name),
+                image_b64=image_b64,
+                error=error,
+            )
+        )
+
+    logger.info(
+        "crop: ran=%d produced=%d crashed=%d",
+        len(crops),
+        sum(1 for c in crops if c.image_b64 is not None),
+        sum(1 for c in crops if c.error is not None),
+    )
+
+    return CropResponse(crops=crops)

--- a/tests/unit/openapi_snapshot.json
+++ b/tests/unit/openapi_snapshot.json
@@ -1,6 +1,31 @@
 {
   "components": {
     "schemas": {
+      "Body_crop_alternatives_crop_post": {
+        "properties": {
+          "image": {
+            "format": "binary",
+            "title": "Image",
+            "type": "string"
+          },
+          "strategy": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Strategy"
+          }
+        },
+        "required": [
+          "image"
+        ],
+        "title": "Body_crop_alternatives_crop_post",
+        "type": "object"
+      },
       "Body_process_process_post": {
         "properties": {
           "image": {
@@ -29,6 +54,66 @@
           }
         },
         "title": "Body_process_process_post",
+        "type": "object"
+      },
+      "CropResponse": {
+        "description": "Response body for POST /crop.\n\n`crops` is a list with one entry per strategy that was run:\n  - one entry when `strategy` was supplied\n  - len(STRATEGY_NAMES) entries when it was omitted\nOrder matches `cropper.STRATEGY_NAMES` (the canonical cascade order).",
+        "properties": {
+          "crops": {
+            "items": {
+              "$ref": "#/components/schemas/CropStrategyOutput"
+            },
+            "title": "Crops",
+            "type": "array"
+          }
+        },
+        "required": [
+          "crops"
+        ],
+        "title": "CropResponse",
+        "type": "object"
+      },
+      "CropStrategyOutput": {
+        "description": "One strategy's output in a /crop response.\n\n`image_b64` is null when the strategy returned None (ran cleanly but\ncouldn't produce a crop) OR when it raised. The two cases are\ndistinguished by `error`: null means \"ran cleanly, no crop\"; a string\nis the exception class name. Crashes do NOT 5xx the endpoint \u2014 the\nwhole point of /crop is letting the human pick from whatever\nsucceeded, even when one strategy is broken.",
+        "properties": {
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "image_b64": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image B64"
+          },
+          "index": {
+            "title": "Index",
+            "type": "integer"
+          },
+          "strategy": {
+            "title": "Strategy",
+            "type": "string"
+          }
+        },
+        "required": [
+          "strategy",
+          "index",
+          "image_b64",
+          "error"
+        ],
+        "title": "CropStrategyOutput",
         "type": "object"
       },
       "HTTPValidationError": {
@@ -175,6 +260,63 @@
   },
   "openapi": "3.1.0",
   "paths": {
+    "/crop": {
+      "post": {
+        "description": "Run one or all crop strategies on an uploaded image and return raw crops.\n\nCompanion to `/process`: when the cascade's \"best\" pick looks wrong to\na human, this endpoint surfaces the alternatives. No orient, no\nclassify, no gates \u2014 just raw cropped bytes per strategy so a human\ncan pick a different one. If they pick one, they re-POST it to\n`/process` as `precropped` to get the full pipeline.\n\nStrategy identifier (form field):\n  - omitted \u2192 run every strategy in cascade order\n  - name (e.g. `sam`) \u2192 run just that one\n  - 0-based index as a numeric string (e.g. `2`) \u2192 run just that one",
+        "operationId": "crop_alternatives_crop_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-internal-key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Internal-Key"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_crop_alternatives_crop_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CropResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Crop Alternatives"
+      }
+    },
     "/health": {
       "get": {
         "operationId": "health_health_get",

--- a/tests/unit/test_crop_route.py
+++ b/tests/unit/test_crop_route.py
@@ -16,7 +16,6 @@ import pytest
 from fastapi.testclient import TestClient
 from PIL import Image
 
-from app import cropper
 from app.cropper import STRATEGY_NAMES
 from app.main import MAX_IMAGE_BYTES, app
 

--- a/tests/unit/test_crop_route.py
+++ b/tests/unit/test_crop_route.py
@@ -1,0 +1,337 @@
+"""Unit tests for POST /crop.
+
+The /crop endpoint exposes the cascade's individual strategies so a human
+can pick an alternative when the cascade's "best" pick looks wrong. It
+runs no orient, no classify, and applies no gates — every strategy's raw
+output is returned. Crashes from one strategy don't 5xx the whole call;
+they're surfaced as a per-entry `error` field.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+
+import pytest
+from fastapi.testclient import TestClient
+from PIL import Image
+
+from app import cropper
+from app.cropper import STRATEGY_NAMES
+from app.main import MAX_IMAGE_BYTES, app
+
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _set_internal_key(monkeypatch):
+    monkeypatch.setenv("INTERNAL_API_KEY", "test-key")
+
+
+def _jpeg(size: tuple[int, int] = (8, 8), color: str = "white") -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", size, color=color).save(buf, format="JPEG")
+    return buf.getvalue()
+
+
+def _stub_all_strategies(monkeypatch, **overrides):
+    """Stub each cropper to return the value (or callable) from overrides.
+
+    `overrides` keys match _STRATEGIES attr names: trim_dark, trim_light,
+    sam_crop, haiku_bbox_crop. A missing key defaults to None (strategy
+    returns None — ran cleanly, no crop). A value can be either bytes
+    (returned directly) or a callable (called with image_bytes).
+    """
+    defaults = {
+        "trim_dark": None,
+        "trim_light": None,
+        "sam_crop": None,
+        "haiku_bbox_crop": None,
+    }
+    defaults.update(overrides)
+
+    def _wrap(value):
+        if callable(value):
+            return value
+        return lambda _b: value
+
+    monkeypatch.setattr("app.cropper.pil_trim.trim_dark", _wrap(defaults["trim_dark"]))
+    monkeypatch.setattr("app.cropper.pil_trim.trim_light", _wrap(defaults["trim_light"]))
+    monkeypatch.setattr("app.cropper.sam.sam_crop", _wrap(defaults["sam_crop"]))
+    monkeypatch.setattr(
+        "app.cropper.haiku_bbox.haiku_bbox_crop", _wrap(defaults["haiku_bbox_crop"])
+    )
+
+
+class TestAuth:
+    def test_missing_key_returns_401(self):
+        response = client.post("/crop", files={"image": ("card.jpg", _jpeg(), "image/jpeg")})
+        assert response.status_code == 401
+
+    def test_wrong_key_returns_401(self):
+        response = client.post(
+            "/crop",
+            headers={"x-internal-key": "wrong"},
+            files={"image": ("card.jpg", _jpeg(), "image/jpeg")},
+        )
+        assert response.status_code == 401
+
+
+class TestRequestValidation:
+    def test_unsupported_content_type_returns_415(self, monkeypatch):
+        _stub_all_strategies(monkeypatch)
+        response = client.post(
+            "/crop",
+            headers={"x-internal-key": "test-key"},
+            files={"image": ("card.txt", b"not an image", "text/plain")},
+        )
+        assert response.status_code == 415
+
+    def test_empty_image_returns_400(self, monkeypatch):
+        _stub_all_strategies(monkeypatch)
+        response = client.post(
+            "/crop",
+            headers={"x-internal-key": "test-key"},
+            files={"image": ("card.jpg", b"", "image/jpeg")},
+        )
+        assert response.status_code == 400
+
+    def test_oversized_image_returns_413(self, monkeypatch):
+        _stub_all_strategies(monkeypatch)
+        oversized = b"x" * (MAX_IMAGE_BYTES + 1)
+        response = client.post(
+            "/crop",
+            headers={"x-internal-key": "test-key"},
+            files={"image": ("card.jpg", oversized, "image/jpeg")},
+        )
+        assert response.status_code == 413
+
+    def test_missing_image_field_returns_422_from_fastapi(self):
+        # `image` is a required form field on /crop; FastAPI returns 422 if
+        # absent. (Auth runs first; bypass it with the correct header.)
+        response = client.post("/crop", headers={"x-internal-key": "test-key"})
+        assert response.status_code == 422
+
+
+class TestUnknownStrategy:
+    def test_bogus_name_returns_400(self, monkeypatch):
+        _stub_all_strategies(monkeypatch)
+        response = client.post(
+            "/crop",
+            headers={"x-internal-key": "test-key"},
+            files={"image": ("card.jpg", _jpeg(), "image/jpeg")},
+            data={"strategy": "bogus"},
+        )
+        assert response.status_code == 400
+        body = response.json()
+        assert body["error_code"] == "UNKNOWN_STRATEGY"
+        assert body["valid"] == list(STRATEGY_NAMES)
+
+    def test_out_of_range_index_returns_400(self, monkeypatch):
+        _stub_all_strategies(monkeypatch)
+        response = client.post(
+            "/crop",
+            headers={"x-internal-key": "test-key"},
+            files={"image": ("card.jpg", _jpeg(), "image/jpeg")},
+            data={"strategy": "99"},
+        )
+        assert response.status_code == 400
+        assert response.json()["error_code"] == "UNKNOWN_STRATEGY"
+
+    def test_negative_index_returns_400(self, monkeypatch):
+        _stub_all_strategies(monkeypatch)
+        response = client.post(
+            "/crop",
+            headers={"x-internal-key": "test-key"},
+            files={"image": ("card.jpg", _jpeg(), "image/jpeg")},
+            data={"strategy": "-1"},
+        )
+        assert response.status_code == 400
+        assert response.json()["error_code"] == "UNKNOWN_STRATEGY"
+
+
+class TestAllStrategies:
+    def test_no_strategy_runs_all_in_canonical_order(self, monkeypatch):
+        _stub_all_strategies(
+            monkeypatch,
+            trim_dark=b"dark",
+            trim_light=b"light",
+            sam_crop=b"sam",
+            haiku_bbox_crop=b"haiku",
+        )
+
+        response = client.post(
+            "/crop",
+            headers={"x-internal-key": "test-key"},
+            files={"image": ("card.jpg", _jpeg(), "image/jpeg")},
+        )
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert [c["strategy"] for c in body["crops"]] == list(STRATEGY_NAMES)
+        assert [c["index"] for c in body["crops"]] == list(range(len(STRATEGY_NAMES)))
+        assert [base64.b64decode(c["image_b64"]) for c in body["crops"]] == [
+            b"dark",
+            b"light",
+            b"sam",
+            b"haiku",
+        ]
+        assert all(c["error"] is None for c in body["crops"])
+
+    def test_strategy_returning_none_has_null_b64_and_null_error(self, monkeypatch):
+        _stub_all_strategies(
+            monkeypatch,
+            trim_dark=b"dark",
+            trim_light=None,
+            sam_crop=b"sam",
+            haiku_bbox_crop=None,
+        )
+
+        response = client.post(
+            "/crop",
+            headers={"x-internal-key": "test-key"},
+            files={"image": ("card.jpg", _jpeg(), "image/jpeg")},
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        by_name = {c["strategy"]: c for c in body["crops"]}
+        assert by_name["pil_trim_light"]["image_b64"] is None
+        assert by_name["pil_trim_light"]["error"] is None
+        assert by_name["haiku_bbox"]["image_b64"] is None
+        assert by_name["haiku_bbox"]["error"] is None
+
+    def test_strategy_raising_is_captured_not_propagated(self, monkeypatch):
+        def _boom(_b):
+            raise ValueError("strategy crashed")
+
+        _stub_all_strategies(
+            monkeypatch,
+            trim_dark=b"dark",
+            sam_crop=_boom,
+        )
+
+        response = client.post(
+            "/crop",
+            headers={"x-internal-key": "test-key"},
+            files={"image": ("card.jpg", _jpeg(), "image/jpeg")},
+        )
+
+        # One bad strategy must not 5xx the whole endpoint.
+        assert response.status_code == 200, response.text
+        body = response.json()
+        by_name = {c["strategy"]: c for c in body["crops"]}
+        assert by_name["pil_trim_dark"]["error"] is None
+        assert base64.b64decode(by_name["pil_trim_dark"]["image_b64"]) == b"dark"
+        assert by_name["sam"]["image_b64"] is None
+        assert by_name["sam"]["error"] == "ValueError"
+
+
+class TestSingleStrategy:
+    def test_strategy_by_name_runs_only_that_one(self, monkeypatch):
+        sam_calls: list[bytes] = []
+        haiku_calls: list[bytes] = []
+
+        def _sam(b):
+            sam_calls.append(b)
+            return b"sam-out"
+
+        def _haiku(b):
+            haiku_calls.append(b)
+            return b"haiku-out"
+
+        _stub_all_strategies(monkeypatch, sam_crop=_sam, haiku_bbox_crop=_haiku)
+
+        response = client.post(
+            "/crop",
+            headers={"x-internal-key": "test-key"},
+            files={"image": ("card.jpg", _jpeg(), "image/jpeg")},
+            data={"strategy": "sam"},
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert len(body["crops"]) == 1
+        assert body["crops"][0]["strategy"] == "sam"
+        assert body["crops"][0]["index"] == STRATEGY_NAMES.index("sam")
+        assert base64.b64decode(body["crops"][0]["image_b64"]) == b"sam-out"
+        assert len(sam_calls) == 1
+        # Critically: other strategies must NOT run.
+        assert haiku_calls == []
+
+    def test_strategy_by_index_runs_only_that_one(self, monkeypatch):
+        _stub_all_strategies(
+            monkeypatch,
+            trim_dark=b"dark",
+            sam_crop=b"sam",
+        )
+
+        sam_index = STRATEGY_NAMES.index("sam")
+        response = client.post(
+            "/crop",
+            headers={"x-internal-key": "test-key"},
+            files={"image": ("card.jpg", _jpeg(), "image/jpeg")},
+            data={"strategy": str(sam_index)},
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert len(body["crops"]) == 1
+        assert body["crops"][0]["strategy"] == "sam"
+        assert body["crops"][0]["index"] == sam_index
+        assert base64.b64decode(body["crops"][0]["image_b64"]) == b"sam"
+
+    def test_single_strategy_returning_none_returns_one_null_entry(self, monkeypatch):
+        _stub_all_strategies(monkeypatch, sam_crop=None)
+
+        response = client.post(
+            "/crop",
+            headers={"x-internal-key": "test-key"},
+            files={"image": ("card.jpg", _jpeg(), "image/jpeg")},
+            data={"strategy": "sam"},
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["crops"] == [
+            {
+                "strategy": "sam",
+                "index": STRATEGY_NAMES.index("sam"),
+                "image_b64": None,
+                "error": None,
+            }
+        ]
+
+
+class TestStrategiesSeeUploadedBytes:
+    def test_strategies_receive_the_uploaded_image_bytes(self, monkeypatch):
+        # Sanity: bytes flow from upload to strategy unmodified.
+        seen: dict[str, bytes] = {}
+
+        def _make(name):
+            def _fn(b):
+                seen[name] = b
+                return b"out-" + name.encode()
+
+            return _fn
+
+        _stub_all_strategies(
+            monkeypatch,
+            trim_dark=_make("trim_dark"),
+            trim_light=_make("trim_light"),
+            sam_crop=_make("sam_crop"),
+            haiku_bbox_crop=_make("haiku_bbox_crop"),
+        )
+
+        original = _jpeg((40, 20))
+        response = client.post(
+            "/crop",
+            headers={"x-internal-key": "test-key"},
+            files={"image": ("card.jpg", original, "image/jpeg")},
+        )
+
+        assert response.status_code == 200
+        # Every strategy got the same original upload bytes.
+        assert set(seen.keys()) == {"trim_dark", "trim_light", "sam_crop", "haiku_bbox_crop"}
+        for name, data in seen.items():
+            assert data == original, f"{name} saw different bytes than uploaded"

--- a/tests/unit/test_cropper_strategies.py
+++ b/tests/unit/test_cropper_strategies.py
@@ -94,8 +94,7 @@ class TestRunStrategy:
         # Logger formats with %s — check the rendered message includes the
         # strategy name and the exception's str() output.
         assert any(
-            "sam" in rec.getMessage() and "kaboom" in rec.getMessage()
-            for rec in caplog.records
+            "sam" in rec.getMessage() and "kaboom" in rec.getMessage() for rec in caplog.records
         )
 
     def test_unknown_name_raises(self):

--- a/tests/unit/test_cropper_strategies.py
+++ b/tests/unit/test_cropper_strategies.py
@@ -117,13 +117,13 @@ class TestRunStrategyCapturing:
         assert err is None  # critical: ran cleanly, just produced nothing
 
     def test_exception_returns_none_bytes_and_class_name(self, monkeypatch):
-        class CustomBoom(RuntimeError):
+        class CustomBoomError(RuntimeError):
             pass
 
         def _boom(_b):
-            raise CustomBoom("nope")
+            raise CustomBoomError("nope")
 
         monkeypatch.setattr("app.cropper.haiku_bbox.haiku_bbox_crop", _boom)
         produced, err = run_strategy_capturing("haiku_bbox", b"in")
         assert produced is None
-        assert err == "CustomBoom"
+        assert err == "CustomBoomError"

--- a/tests/unit/test_cropper_strategies.py
+++ b/tests/unit/test_cropper_strategies.py
@@ -1,0 +1,129 @@
+"""Unit tests for the public strategy registry/runner helpers in app.cropper.
+
+These primitives back both the cascade in `crop()` and the new `/crop`
+endpoint, so they're tested directly here rather than only through HTTP.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from app import cropper
+from app.cropper import (
+    STRATEGY_NAMES,
+    UnknownStrategyError,
+    resolve_strategy_identifier,
+    run_strategy,
+    run_strategy_capturing,
+)
+
+
+class TestStrategyNames:
+    def test_matches_internal_strategies_list(self):
+        assert STRATEGY_NAMES == ("pil_trim_dark", "pil_trim_light", "sam", "haiku_bbox")
+
+    def test_is_a_tuple(self):
+        # Tuple, not list — STRATEGY_NAMES is meant to be the canonical, immutable order.
+        assert isinstance(STRATEGY_NAMES, tuple)
+
+
+class TestResolveStrategyIdentifier:
+    @pytest.mark.parametrize("name", list(STRATEGY_NAMES))
+    def test_accepts_valid_names(self, name):
+        assert resolve_strategy_identifier(name) == name
+
+    @pytest.mark.parametrize("idx,expected", list(enumerate(STRATEGY_NAMES)))
+    def test_accepts_int_index(self, idx, expected):
+        assert resolve_strategy_identifier(idx) == expected
+
+    @pytest.mark.parametrize("idx,expected", list(enumerate(STRATEGY_NAMES)))
+    def test_accepts_numeric_string_index(self, idx, expected):
+        assert resolve_strategy_identifier(str(idx)) == expected
+
+    def test_unknown_name_raises(self):
+        with pytest.raises(UnknownStrategyError, match="unknown strategy"):
+            resolve_strategy_identifier("not_a_real_strategy")
+
+    def test_out_of_range_int_raises(self):
+        with pytest.raises(UnknownStrategyError, match="out of range"):
+            resolve_strategy_identifier(99)
+
+    def test_out_of_range_numeric_string_raises(self):
+        with pytest.raises(UnknownStrategyError, match="out of range"):
+            resolve_strategy_identifier("99")
+
+    def test_negative_int_raises(self):
+        with pytest.raises(UnknownStrategyError, match="out of range"):
+            resolve_strategy_identifier(-1)
+
+    def test_negative_numeric_string_raises(self):
+        with pytest.raises(UnknownStrategyError, match="out of range"):
+            resolve_strategy_identifier("-1")
+
+    def test_bool_rejected(self):
+        # bool is an int subclass; we explicitly reject it because True == 1
+        # would silently resolve to STRATEGY_NAMES[1] which is surprising.
+        with pytest.raises(UnknownStrategyError):
+            resolve_strategy_identifier(True)
+
+    def test_non_numeric_junk_raises(self):
+        with pytest.raises(UnknownStrategyError, match="unknown strategy"):
+            resolve_strategy_identifier("abc123")
+
+
+class TestRunStrategy:
+    def test_returns_bytes_when_strategy_returns_bytes(self, monkeypatch):
+        monkeypatch.setattr("app.cropper.sam.sam_crop", lambda _b: b"cropped")
+        assert run_strategy("sam", b"in") == b"cropped"
+
+    def test_returns_none_when_strategy_returns_none(self, monkeypatch):
+        monkeypatch.setattr("app.cropper.sam.sam_crop", lambda _b: None)
+        assert run_strategy("sam", b"in") is None
+
+    def test_returns_none_when_strategy_raises(self, monkeypatch, caplog):
+        def _boom(_b):
+            raise RuntimeError("kaboom")
+
+        monkeypatch.setattr("app.cropper.sam.sam_crop", _boom)
+
+        with caplog.at_level(logging.WARNING, logger=cropper.__name__):
+            assert run_strategy("sam", b"in") is None
+
+        # Logger formats with %s — check the rendered message includes the
+        # strategy name and the exception's str() output.
+        assert any(
+            "sam" in rec.getMessage() and "kaboom" in rec.getMessage()
+            for rec in caplog.records
+        )
+
+    def test_unknown_name_raises(self):
+        with pytest.raises(UnknownStrategyError):
+            run_strategy("not_a_strategy", b"in")
+
+
+class TestRunStrategyCapturing:
+    def test_success_returns_bytes_and_none_error(self, monkeypatch):
+        monkeypatch.setattr("app.cropper.haiku_bbox.haiku_bbox_crop", lambda _b: b"crop")
+        produced, err = run_strategy_capturing("haiku_bbox", b"in")
+        assert produced == b"crop"
+        assert err is None
+
+    def test_none_return_is_distinct_from_exception(self, monkeypatch):
+        monkeypatch.setattr("app.cropper.haiku_bbox.haiku_bbox_crop", lambda _b: None)
+        produced, err = run_strategy_capturing("haiku_bbox", b"in")
+        assert produced is None
+        assert err is None  # critical: ran cleanly, just produced nothing
+
+    def test_exception_returns_none_bytes_and_class_name(self, monkeypatch):
+        class CustomBoom(RuntimeError):
+            pass
+
+        def _boom(_b):
+            raise CustomBoom("nope")
+
+        monkeypatch.setattr("app.cropper.haiku_bbox.haiku_bbox_crop", _boom)
+        produced, err = run_strategy_capturing("haiku_bbox", b"in")
+        assert produced is None
+        assert err == "CustomBoom"


### PR DESCRIPTION
## Summary
- Adds `POST /crop`, a companion to `/process` for when the cascade's "best" pick looks wrong to a human. Runs one strategy (by name or 0-based index) or all of them and returns raw cropped bytes per strategy — no orient, no classify, no gates. Caller re-POSTs the chosen crop to `/process` as `precropped` for the full pipeline.
- Refactors the cascade so `/process` and `/crop` share the per-strategy primitive: `STRATEGY_NAMES`, `resolve_strategy_identifier`, `run_strategy`, `run_strategy_capturing`. The cascade loop now calls `run_strategy` instead of duplicating the `getattr` + try/except block.
- Per-strategy crashes never 5xx the endpoint — they surface as a per-entry `error` (exception class name) so the human still sees whatever else succeeded.

## Test plan
- [x] `pytest tests/unit/ -q` — 189 passed (28 new, no regressions in cascade or process-route)
- [x] OpenAPI snapshot regenerated to include `/crop`
- [ ] Manual smoke against a running dev server:
  - `curl -F image=@card.jpg -H "x-internal-key: ..." :8000/crop` → 4 entries in canonical order
  - `curl -F image=@card.jpg -F strategy=sam -H "x-internal-key: ..." :8000/crop` → 1 entry, `strategy=sam`, `index=2`
  - `curl -F image=@card.jpg -F strategy=2 -H "x-internal-key: ..." :8000/crop` → same as above
  - `curl -F image=@card.jpg -F strategy=bogus -H "x-internal-key: ..." :8000/crop` → 400 `UNKNOWN_STRATEGY`
  - `curl -F image=@card.jpg -H "x-internal-key: ..." :8000/process` → unchanged (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)